### PR TITLE
added generic public ecr push workflow from aoc repo

### DIFF
--- a/.github/workflows/build-and-push.public-ecr.yaml
+++ b/.github/workflows/build-and-push.public-ecr.yaml
@@ -97,5 +97,5 @@ jobs:
           aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/aws-observability
           docker tag ${{ steps.validate-inputs.outputs.ECR_REPO_NAME }} public.ecr.aws/aws-observability/${{ steps.validate-inputs.outputs.ECR_REPO_NAME }}:${{ github.event.inputs.version }}
           docker tag ${{ steps.validate-inputs.outputs.ECR_REPO_NAME }} public.ecr.aws/aws-observability/${{ steps.validate-inputs.outputs.ECR_REPO_NAME }}:latest 
-          docker push public.ecr.aws/$ECR_REPO:${{ github.event.inputs.version }}
-          docker push public.ecr.aws/$ECR_REPO:latest
+          docker push public.ecr.aws/aws-observability/${{ steps.validate-inputs.outputs.ECR_REPO_NAME }}:${{ github.event.inputs.version }}
+          docker push public.ecr.aws/aws-observability/${{ steps.validate-inputs.outputs.ECR_REPO_NAME }}:latest


### PR DESCRIPTION
Moved the generic workflow from aoc repo to here, but it will not work until the secrets are configured same way as in aoc repo.

Logic to determine ecr repo is as follows:
- if inputted github repo == inputted ecr_repo, then that is the ecr repo
- else, find ecr repo from ECR_REPO file that is located at the same level as the Dockerfile
- if ECR_REPO file doesnt exist, throw error