### PR TITLE
[charts/datadog-exporter-for-eks-on-ec2] Add Datadog exporter Helm chart

### DIFF
--- a/charts/datadog-exporter-for-eks-on-ec2/Chart.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: datadog-exporter-for-eks-on-ec2
+description: A Helm chart for collecting metrics using ADOT Collector to send to Datadog.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.16.0-0"
+maintainers:
+  - name: Datadog
+    email: support@datadoghq.com
+home: https://github.com/aws-observability/aws-otel-helm-charts/datadog-exporter-for-eks-on-ec2
+sources:
+  - https://github.com/aws-observability/aws-otel-helm-charts/datadog-exporter-for-eks-on-ec2

--- a/charts/datadog-exporter-for-eks-on-ec2/Makefile
+++ b/charts/datadog-exporter-for-eks-on-ec2/Makefile
@@ -1,0 +1,21 @@
+# Source Code from: https://github.com/aws/eks-charts
+# Run `make install-tools`, then `make all` for chart validation test and lint
+REPO_ROOT ?= $(shell git rev-parse --show-toplevel)
+
+.PHONY:all
+all: validate lint
+
+install-tools:
+	${REPO_ROOT}/charts/datadog-exporter-for-eks-on-ec2/scripts/install-tools.sh
+
+.PHONY: validate
+validate:
+	${REPO_ROOT}/charts/datadog-exporter-for-eks-on-ec2/scripts/validate-charts.sh
+
+.PHONY: lint
+lint:
+	${REPO_ROOT}/charts/datadog-exporter-for-eks-on-ec2/scripts/lint-charts.sh
+
+.PHONY: clean
+clean:
+	rm -rf ${REPO_ROOT}/build/

--- a/charts/datadog-exporter-for-eks-on-ec2/README.md
+++ b/charts/datadog-exporter-for-eks-on-ec2/README.md
@@ -1,0 +1,181 @@
+# ADOT Helm chart for EKS on EC2 metrics to Datadog
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+This [Helm](https://helm.sh/) chart provides easy to use [AWS Elastic Kubernetes Service](https://aws.amazon.com/eks/) (EKS) on [AWS Elastic Compute Cloud](https://aws.amazon.com/ec2/) (EC2) monitoring with [AWS Distro for OpenTelemetry(ADOT) Collector](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-EKS-otel.html) for metrics and send them to [Datadog](https://www.datadoghq.com). Therefore, the Helm chart is useful for customers who use EKS on EC2 and want to collect metrics to send to Datadog.
+
+The Helm chart configured in this repository deploys the ADOT Collector as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) and is ready to collect metrics and send them to Datadog.
+
+## Helm Chart Structure
+```console
+datadog-exporter-for-eks-on-ec2/
+|-- scripts/ 
+|   |-- install-tools.sh
+|   |-- lint-charts.sh
+|   |-- validate-charts.sh
+|-- templates/
+|   |-- NOTES.txt
+|   |-- adot-collector/
+|   |   |-- _helpers.tpl
+|   |   |-- clusterrole.yaml
+|   |   |-- clusterrolebinding.yaml
+|   |   |-- configmap.yaml
+|   |   |-- daemonset.yaml
+|   |   |-- namespace.yaml
+|   |   |-- serviceaccount.yaml
+|   |   |-- sidecar.yaml
+|   |   |-- sidecarnamespace.yaml
+|-- Chart.yaml
+|-- values.schema.json
+|-- values.yaml
+|-- Makefile
+|-- README.md
+```
+
+`templates` folder contains one subfolder, `adot-collector`, and each subfolder contains template files that will be evaluated with the default values configured in `values.yaml.`
+
+`script` folder contains shell script files to run chart validation and lint tests with [Helm Lint](https://helm.sh/docs/helm/helm_lint/) and [Kubeval](https://kubeval.instrumenta.dev/).
+
+`values.yaml` file stores parameterized template defaults in the Helm chart. Using this file, we can provide more flexibility to our users to expose configuration that can be overriden at installation and upgrade time.
+
+`values.schema.json` file contains schemas of each values in values.yaml. It defines each values’ type, required keys, and constraints.
+
+`_helpers.tpl` files are used to define GO template helpers to create name variables.
+
+## Prerequisites
+
+The following prerequisites need to be set up in order to install this Helm chart.
+
+- Your EKS Cluster on EC2 
+- A valid [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/)
+- [Helm v3+](https://helm.sh/docs/helm/helm_install/)
+
+## Get Repository Information
+
+[Helm](https://helm.sh/) must be installed to use the chart. Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add this repo as follows:
+```console
+$ helm repo add [REPO_NAME] https://aws-observability.github.io/aws-otel-helm-charts
+$ helm search repo [REPO_NAME] # Run this command in order to see the charts.
+```
+
+## Install Chart
+
+```console
+$ helm install \
+  [RELEASE_NAME] [REPO_NAME]/datadog-exporter-for-eks-on-ec2 \
+  --set clusterName=[CLUSTER_NAME] --set awsRegion=[AWS_REGION] --set adotCollector.daemonSet.exporters.datadog.api.key=[API_KEY]
+```
+
+`CLUSTER_NAME` and `AWS_REGION` must be specified with your own EKS cluster and the region.
+You can find these values by executing following command.
+
+```console
+$ kubectl config current-context
+
+[IAM_User_Name]@[CLUSTER_NAME].[AWS_REGION].eksctl.io
+```
+
+`API_KEY` is a valid Datadog API key. It can be found on your [organization page](https://app.datadoghq.com/organization-settings/api-keys). Your API key will be stored in a Secret.
+
+To verify the installation is successful, you can execute the following command.
+
+```console
+$ kubectl get pods --all-namespaces
+
+NAMESPACE                NAME                             READY   STATUS    RESTARTS   AGE
+datadog-adot-metrics  adot-collector-daemonset-7nrst   1/1     Running   0          4s
+datadog-adot-metrics  adot-collector-daemonset-x7n8x   1/1     Running   0          4s
+```
+
+If you see these two running pods for ADOT Collector as [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) within the specified namespace, they are successfully deployed.
+
+### Verify the Helm chart works as expected
+- Run chart validation test and lint from`MakeFile`.
+```console
+$ cd datadog-exporter-for-eks-on-ec2
+$ make install-tools # required initially
+$ make all           # to run chart validation test and lint 
+```
+
+### Verify the metrics are sent to Datadog
+
+- Open the Datadog webapp
+- Navigate to the [Metrics > Summary page](https://app.datadoghq.com/metric/summary)
+- Check that the [AWS Container Insights metrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awscontainerinsightreceiver#available-metrics-and-resource-attributes) are reported. They may take a few minutes to come up.
+
+## Configuration
+To see all configurable options with detailed comments:
+
+```console
+$ helm show values [REPO_NAME]/datadog-exporter-for-eks-on-ec2
+```
+
+By changing values in `values.yaml`, you are able to customize the chart to use your preferred configuration.
+
+Following options are some useful configurations that can be applied to this Helm chart.
+
+### Deploy ADOT Collector as a Sidecar
+
+A sidecar is a microservice design pattern where a companion service runs next to your primary microservice, augmenting its abilities or intercepting resources it is utilizing. The sidecar pattern would be the best fit for a single application monitoring.
+
+In order to deploy the ADOT Collector in Sidecar mode using the Helm chart, 1) update `sidecar.yaml` and `values.yaml` files in the Helm chart with the application configurations and 2) include the use of `--set` flag in the `helm install` command from [Install Chart](#install-chart).
+
+```console
+$ helm install \
+  [RELEASE_NAME] [REPO_NAME]/datadog-exporter-for-eks-on-ec2 \
+  --set clusterName=[CLUSTER_NAME] --set awsRegion=[AWS_REGION] \
+  --set adotCollector.daemonSet.enabled=false --set adotCollector.sidecar.enabled=true
+```
+The use of `--set` flag with `enabled=true` or `enabled=false` can switch on/off the specified deployment mode. The command set `enabled=false` for ADOT Collector as DaemonSet and `enabled=true` to deploy ADOT Collector as Sidecar.
+You can also check whether your applications are successfully deployed by executing the following command.
+
+```console
+$ kubectl get pods --all-namespaces
+
+NAMESPACE                NAME                            READY   STATUS    RESTARTS   AGE
+adot-sidecar-namespace   adot-sidecar-658dc9ffbb-w9zv2   2/2     Running   0          5m18s
+```
+
+### Deploy ADOT Collector as Deployment and StatefulSet
+
+Deploying ADOT Collector as Deployment and StatefulSet mode requires installing ADOT Operator. See [OpenTelemetry Operator Helm Chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-operator) for detailed explanation.
+
+
+### Deploy ADOT Collector with Prometheus Receiver for AWS Container Insights on EKS
+
+Please refer to [deployment template](https://github.com/aws-observability/aws-otel-collector/blob/main/deployment-template/eks/otel-container-insights-prometheus.yaml) to deploy ADOT Collector with [Prometheus Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/d46048ac4dd01062c803867cb6a13377ea287a23/receiver/prometheusreceiver/README.md#prometheus-receiver) and [Datadog Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter) for AWS Container Insights on EKS 
+via [configurations](https://github.com/aws-observability/aws-otel-collector/blob/main/config/eks/prometheus/config-all.yaml) in the Helm chart.
+
+## Uninstall Chart
+
+The following command uninstalls the chart. 
+This will remove all the Kubernetes components associated with the chart and deletes the release.
+
+```console
+$ helm uninstall [RELEASE_NAME]
+```
+
+## Upgrade Chart
+
+```console
+$ helm upgrade [RELEASE_NAME] [REPO_NAME]/datadog-exporter-for-eks-on-ec2
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md).
+
+## Other useful links
+
+[Using AWS Distro for OpenTelemetry](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-EKS-otel.html)
+
+[AWS OpenTelemetry Collector Datadog exporter](https://aws-otel.github.io/docs/partners/datadog)
+
+## License
+
+Apache 2.0 License.
+
+## Support
+
+This is a supported Datadog product. Please [reach out](https://www.datadoghq.com/support/) if you need help.

--- a/charts/datadog-exporter-for-eks-on-ec2/scripts/install-tools.sh
+++ b/charts/datadog-exporter-for-eks-on-ec2/scripts/install-tools.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$([[ $(uname -m) = "x86_64" ]] && echo 'amd64' || echo 'arm64')
+ROOT_PROJECT=$(git rev-parse --show-toplevel)
+BUILD_DIR="${ROOT_PROJECT}/build"
+TMP_DIR="${BUILD_DIR}/tmp"
+TOOLS_DIR="${BUILD_DIR}/tools"
+mkdir -p "${TOOLS_DIR}"
+export PATH="${TOOLS_DIR}:${PATH}"
+
+HELM_VERSION_TAG=$(curl -sSL https://github.com/helm/helm/releases/latest | sed -n '/<title>/,$p' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+HELM_VERSION=v${HELM_VERSION_TAG}
+
+## Install kubeval
+mkdir -p "${TMP_DIR}/kubeval"
+curl -sSL https://github.com/instrumenta/kubeval/releases/latest/download/kubeval-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/kubeval"
+mv "${TMP_DIR}/kubeval/kubeval" "${TOOLS_DIR}/kubeval"
+
+## Install helm v3
+mkdir -p "${TMP_DIR}/helmv3"
+curl -sSL https://get.helm.sh/helm-${HELM_VERSION}-${PLATFORM}-${ARCH}.tar.gz | tar xz -C "${TMP_DIR}/helmv3"
+mv "${TMP_DIR}/helmv3/${PLATFORM}-${ARCH}/helm" "${TOOLS_DIR}/helmv3"
+rm -rf "${PLATFORM}-${ARCH}"
+
+## Remove TMP directory
+rm -rf ${TMP_DIR}
+
+# Source Code from: https://github.com/aws/eks-charts

--- a/charts/datadog-exporter-for-eks-on-ec2/scripts/lint-charts.sh
+++ b/charts/datadog-exporter-for-eks-on-ec2/scripts/lint-charts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_PROJECT=$(git rev-parse --show-toplevel)
+BUILD_DIR="${ROOT_PROJECT}/build"
+TOOLS_DIR="${BUILD_DIR}/tools"
+CHART_DIR="${ROOT_PROJECT}/charts/datadog-exporter-for-eks-on-ec2"
+export PATH="${TOOLS_DIR}:${PATH}"
+
+FAILED_V3=()
+
+echo "Linting chart ${CHART_DIR} with Helm v3"
+helmv3 lint ${CHART_DIR}/ || FAILED_V3+=("${CHART_DIR}")
+
+if  [[ "${#FAILED_V3[@]}" -eq 0 ]]; then
+    echo "All charts passed linting!"
+    exit 0
+else
+    echo "Helm v3:"
+    for chart in "${FAILED_V3[@]}"; do
+        printf "%40s ❌\n" "$chart"
+    done
+fi
+
+# Source Code from: https://github.com/aws/eks-charts

--- a/charts/datadog-exporter-for-eks-on-ec2/scripts/validate-charts.sh
+++ b/charts/datadog-exporter-for-eks-on-ec2/scripts/validate-charts.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_PROJECT=$(git rev-parse --show-toplevel)
+BUILD_DIR="${ROOT_PROJECT}/build"
+TOOLS_DIR="${BUILD_DIR}/tools"
+CHART_DIR="${ROOT_PROJECT}/charts/datadog-exporter-for-eks-on-ec2"
+export PATH="${TOOLS_DIR}:${PATH}"
+
+FAILED_V3=()
+
+echo "Chart validation ${CHART_DIR} with Helm v3"
+helmv3 template ${CHART_DIR} | kubeval || FAILED_V3+=("${CHART_DIR}")
+
+if  [[ "${#FAILED_V3[@]}" -eq 0 ]]; then
+    echo "All charts passed validation tests!"
+    exit 0
+else
+    echo "Helm v3:"
+    for chart in "${FAILED_V3[@]}"; do
+        printf "%40s ❌\n" "$chart"
+    done
+fi
+
+# Source Code from: https://github.com/aws/eks-charts

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/NOTES.txt
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/NOTES.txt
@@ -1,0 +1,19 @@
+{{- if (not (eq .Values.adotCollector.daemonSet.exporters.datadog.api.key "<DATADOG_API_KEY>")) }}
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+{{- else }}
+##############################################################################
+####               ERROR: You did not set a Datadog API Key               ####
+##############################################################################
+
+This deployment will be incomplete until you get your API key from Datadog.
+Please set your API key at 'adotCollector.daemonSet.exporters.datadog.api.key', 
+then upgrade the release.
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/_helpers.tpl
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/_helpers.tpl
@@ -1,0 +1,91 @@
+{{/* vim: set filetype=mustache: */}}
+{{/* chart specific names and labels that may be re-used in the chart */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "adotCollector.daemonSet.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "adotCollector.daemonSet.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "adotCollector.daemonSet.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "adotCollector.daemonSet.labels" -}}
+helm.sh/chart: {{ include "adotCollector.daemonSet.chart" . }}
+{{ include "adotCollector.daemonSet.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "adotCollector.daemonSet.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "adotCollector.daemonSet.name" . }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "adotCollector.daemonSet.serviceAccountName" -}}
+  {{ default (include "adotCollector.daemonSet.fullname" .) .Values.adotCollector.daemonSet.serviceAccount.name }}
+{{- end -}}
+
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "adotCollector.daemonSet.namespace" -}}
+  {{- if .Values.global -}}
+    {{- if .Values.global.namespaceOverride -}}
+      {{- .Values.global.namespaceOverride -}}
+    {{- else -}}
+      {{- .Values.adotCollector.daemonSet.namespace -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Values.adotCollector.daemonSet.namespace -}}
+  {{- end -}}
+{{- end -}}
+
+
+{{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "adotCollector.sidecar.namespace" -}}
+  {{- if .Values.global -}}
+    {{- if .Values.global.namespaceOverride -}}
+      {{- .Values.global.namespaceOverride -}}
+    {{- else -}}
+      {{- .Values.adotCollector.sidecar.namespace -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Values.adotCollector.sidecar.namespace -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# ClusterRole for ADOT Collector as a DaemonSet contains rules, and defines and grants permissions to specified resources/endpoints.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.clusterRoleName }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "nodes", "endpoints"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["nodes/stats", "configmaps", "events"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["adot-container-insight-clusterleader"]
+    verbs: ["get","update"]
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/clusterrolebinding.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# ClusterRoleBinding for ADOT Collector as a DaemonSet references and grants permissions defined in ClusterRole to service accounts/users/groups in subjects.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.clusterRoleBindingName }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.adotCollector.daemonSet.serviceAccount.name }}
+  namespace: {{ include "adotCollector.daemonSet.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.adotCollector.daemonSet.clusterRoleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# ConfigMap for ADOT Collector as a DaemonSet with the specified configurations, including configured values from values.yaml.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.configMap.name }}
+  namespace: {{ .Values.adotCollector.daemonSet.namespace }}
+  labels:
+    app: {{ .Values.adotCollector.daemonSet.configMap.app }}
+    component: {{ .Values.adotCollector.daemonSet.configMap.component }}
+data:
+  adot-config: |
+    extensions:
+      health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
+    receivers:
+      awscontainerinsightreceiver:
+        collection_interval: {{ .Values.adotCollector.daemonSet.receivers.collectionInterval }}
+        container_orchestrator: {{ .Values.adotCollector.daemonSet.receivers.containerOrchestrator }}
+        add_service_as_attribute: {{ .Values.adotCollector.daemonSet.receivers.addServiceAsAttribute }}
+        prefer_full_pod_name: {{ .Values.adotCollector.daemonSet.receivers.preferFullPodName }}
+    processors:
+      batch/metrics:
+        timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
+      resourcedetection/k8s:
+        detectors: [env]
+        override: false
+    exporters:
+      datadog:
+        api:
+          key: "${DATADOG_INTERNAL_API_KEY}"
+          site: {{ .Values.adotCollector.daemonSet.exporters.datadog.api.site }}
+        metrics:
+          resource_attributes_as_tags: {{ .Values.adotCollector.daemonSet.exporters.datadog.metrics.resource_attributes_as_tags }}
+        use_resource_metadata: {{ .Values.adotCollector.daemonSet.exporters.datadog.use_resource_metadata }}
+    service:
+      pipelines:
+        metrics:
+          receivers: {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
+          - {{.}}{{- end }}
+          processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
+          - {{.}}{{- end }}
+          exporters: {{- range .Values.adotCollector.daemonSet.service.metrics.exporters }}
+          - {{.}}{{- end }}
+      extensions: {{- range .Values.adotCollector.daemonSet.service.extensions }}
+      - {{.}}{{- end }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# ADOT Collector as a DaemonSet for deployment.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.daemonSetName }}
+  namespace: {{ .Values.adotCollector.daemonSet.namespace }}
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Values.adotCollector.daemonSet.daemonSetName }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.adotCollector.daemonSet.daemonSetName }}
+    spec:
+      containers:
+        - name: {{ .Values.adotCollector.daemonSet.containersName }}
+          image: "{{ .Values.adotCollector.image.repository }}:{{ .Values.adotCollector.image.tag }}"
+          imagePullPolicy: {{ .Values.adotCollector.image.daemonSetPullPolicy }}
+          env:
+            - name: DATADOG_INTERNAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.adotCollector.daemonSet.datadogAPIKeySecretName }}
+                  key: api-key
+                  optional: true
+            - name: "DATADOG_INTERNAL_K8S_NODE_NAME"
+              valueFrom:
+                fieldRef:
+                  fieldPath: "spec.nodeName"
+            - name: "OTEL_RESOURCE_ATTRIBUTES"
+              value: k8s.node.name=$(DATADOG_INTERNAL_K8S_NODE_NAME)
+            {{- with .Values.adotCollector.daemonSet.env }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
+          command:
+            {{- toYaml .Values.adotCollector.daemonSet.command | nindent 12}}
+          volumeMounts:
+            {{- toYaml .Values.adotCollector.daemonSet.volumeMounts | nindent 12 }}
+          resources:
+            {{- toYaml .Values.adotCollector.daemonSet.resources | nindent 12 }}
+      volumes:
+        {{- toYaml .Values.adotCollector.daemonSet.volumes | nindent 10 }}
+      serviceAccountName: {{ .Values.adotCollector.daemonSet.serviceAccount.name  }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/namespace.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/namespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# Specify namespace for ADOT Collector as a DaemonSet.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "adotCollector.daemonSet.namespace" . }}
+  labels:
+    name: {{ include "adotCollector.daemonSet.namespace" . }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/secretapikey.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/secretapikey.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.datadogAPIKeySecretName }}
+  namespace: {{ .Values.adotCollector.daemonSet.namespace }}
+type: Opaque
+data:
+  api-key: {{ default "MISSING" .Values.adotCollector.daemonSet.exporters.datadog.api.key | b64enc | quote }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.adotCollector.daemonSet.enabled }}
+# Service account provides identity information for a user to be able to authenticate processes running in a pod.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.adotCollector.daemonSet.serviceAccount.name }}
+  namespace: {{ include "adotCollector.daemonSet.namespace" . }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/sidecar.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/sidecar.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.adotCollector.sidecar.enabled }}
+# ADOT Collector as a Sidecar for deployment.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.adotCollector.sidecar.name }}
+  namespace: {{ .Values.adotCollector.sidecar.namespace }}
+  labels:
+    name: {{ .Values.adotCollector.sidecar.name }}
+spec:
+  replicas: {{ .Values.adotCollector.sidecar.replicas }}
+  selector:
+    matchLabels:
+      name: {{ .Values.adotCollector.sidecar.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.adotCollector.sidecar.name }}
+    spec:
+      containers:
+        - name: "{{ .Values.adotCollector.sidecar.image.name }}"
+          image: "{{ .Values.adotCollector.sidecar.image.repository }}:{{ .Values.adotCollector.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.adotCollector.sidecar.image.pullPolicy }}
+        - name: "{{ .Values.adotCollector.image.name }}"
+          image: "{{ .Values.adotCollector.image.repository }}:{{ .Values.adotCollector.image.tag }}"
+          env:
+            - name: AWS_REGION
+              value: {{ .Values.awsRegion }}
+          imagePullPolicy: {{ .Values.adotCollector.image.sidecarPullPolicy }}
+          resources:
+            {{- toYaml .Values.adotCollector.sidecar.resources | nindent 12 }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/sidecarnamespace.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/templates/adot-collector/sidecarnamespace.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.adotCollector.sidecar.enabled }}
+# Specify namespace for ADOT Collector as a Sidecar.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "adotCollector.sidecar.namespace" . }}
+  labels:
+    name: {{ include "adotCollector.sidecar.namespace" . }}
+{{- end }}

--- a/charts/datadog-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/datadog-exporter-for-eks-on-ec2/values.schema.json
@@ -1,0 +1,663 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "nameOverride": {
+            "type": "string"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "namespaceOverride": {
+                    "type": "string"
+                }
+            }
+        },
+        "awsRegion": {
+            "type": "string"
+        },
+        "clusterName": {
+            "type": "string"
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "create": {
+                    "type": "boolean"
+                },
+                "annotations": {
+                    "type": "object"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "adotCollector": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "required": [
+                        "repository",
+                        "daemonSetPullPolicy",
+                        "sidecarPullPolicy"
+                    ],
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "pattern": "^[/a-z0-9-_]+$"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "daemonSetPullPolicy": {
+                            "type": "string",
+                            "pattern": "^(Always|Never|IfNotPresent)$"
+                        },
+                        "sidecarPullPolicy": {
+                            "type": "string",
+                            "pattern": "^(Always|Never|IfNotPresent)$"
+                        }
+                    }
+                },
+                "daemonSet": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "daemonSetName": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "namespaceOverride": {
+                            "type": "string"
+                        },
+                        "serviceAccount": {
+                            "type": "object",
+                            "properties": {
+                                "create": {
+                                    "type": "boolean"
+                                },
+                                "name": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "clusterRoleName": {
+                            "type": "string"
+                        },
+                        "clusterRoleBindingName": {
+                            "type": "string"
+                        },
+                        "datadogAPIKeySecretName": {
+                            "type": "string"
+                        },
+                        "configMap": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "app": {
+                                    "type": "string"
+                                },
+                                "component": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "containersName": {
+                            "type": "string"
+                        },
+                        "env": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "fieldPath": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "fieldPath": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "fieldPath": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "valueFrom": {
+                                            "type": "object",
+                                            "properties": {
+                                                "fieldRef": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "fieldPath": {
+                                                            "type": "string"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "value": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "command": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "configMap": {
+                                            "type": "object",
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string"
+                                                },
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": [
+                                                        {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "path": {
+                                                                    "type": "string"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "name": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "volumeMounts": {
+                            "type": "array",
+                            "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "extensions": {
+                            "type": "object",
+                            "properties": {
+                                "healthCheck": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "receivers": {
+                            "type": "object",
+                            "properties": {
+                                "collectionInterval": {
+                                    "type": "string"
+                                },
+                                "containerOrchestrator": {
+                                    "type": "string"
+                                },
+                                "addServiceAsAttribute": {
+                                    "type": "string"
+                                },
+                                "preferFullPodName": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "processors": {
+                            "type": "object",
+                            "properties": {
+                                "timeout": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "exporters": {
+                            "type": "object",
+                            "properties": {
+                                "datadog": {
+                                    "type": "object",
+                                    "properties": {
+                                        "api": {
+                                            "type": "object",
+                                            "properties": {
+                                                "key": {
+                                                    "type": "string"
+                                                },
+                                                "site": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "metrics": {
+                                            "type": "object",
+                                            "properties": {
+                                                "resource_attributes_as_tags": {
+                                                    "type": "boolean"
+                                                }
+                                            }
+                                        },
+                                        "traces": {
+                                            "type": "object",
+                                            "properties": {
+                                                "span_name_as_resource_name": {
+                                                    "type": "boolean"
+                                                }                                                
+                                            }
+                                        },
+                                        "use_resource_metadata": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "service": {
+                            "type": "object",
+                            "properties": {
+                                "metrics": {
+                                    "type": "object",
+                                    "properties": {
+                                        "receivers": {
+                                            "type": "array",
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        },
+                                        "processors": {
+                                            "type": "array",
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        },
+                                        "exporters": {
+                                            "type": "array",
+                                            "items": [
+                                                {
+                                                    "type": "string"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                "extensions": {
+                                    "type": "array",
+                                    "items": [
+                                        {
+                                            "type": "string"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "sidecar": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "namespaceOverride": {
+                            "type": "string"
+                        },
+                        "regionS3": {
+                            "type": "string"
+                        },
+                        "replicas": {
+                            "type": "integer"
+                        },
+                        "image": {
+                            "type": "object",
+                            "required": [
+                                "repository",
+                                "pullPolicy"
+                            ],
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "repository": {
+                                    "type": "string",
+                                    "pattern": "(^$|^[/a-z0-9-_]+)$"
+                                },
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "pullPolicy": {
+                                    "type": "string",
+                                    "pattern": "(^$|^(Always|Never|IfNotPresent))$"
+                                }
+                            }
+                        },
+                        "otelOtlpEndPointValue": {
+                            "type": "string"
+                        },
+                        "otelResourceAttributesValue": {
+                            "type": "string"
+                        },
+                        "resources": {
+                            "type": "object",
+                            "properties": {
+                                "limits": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                },
+                                "requests": {
+                                    "type": "object",
+                                    "properties": {
+                                        "cpu": {
+                                            "type": "string"
+                                        },
+                                        "memory": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/charts/datadog-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/datadog-exporter-for-eks-on-ec2/values.yaml
@@ -1,0 +1,145 @@
+nameOverride: ""
+fullnameOverride: ""
+global:
+  namespaceOverride: ""
+awsRegion: ""
+clusterName: ""
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+adotCollector:
+  image:
+    name: "aws-otel-collector"
+    repository: "amazon/aws-otel-collector"
+    tag: "v0.14.0"
+    daemonSetPullPolicy: "IfNotPresent"
+    sidecarPullPolicy: "Always"
+  daemonSet:
+    enabled: true
+    daemonSetName: "adot-collector-daemonset"
+    namespace: "datadog-adot-metrics"
+    namespaceOverride: ""
+    serviceAccount:
+      create: true
+      name: "adot-collector-sa"
+    clusterRoleName: "adot-collector-role"
+    clusterRoleBindingName: "adot-collector-role-binding"
+    datadogAPIKeySecretName: "datadog-secret-api-key"
+    configMap:
+      name: "adot-conf"
+      app: "opentelemetry"
+      component: "adot-conf"
+    containersName: "adot-collector-container"
+    env:
+      - name: "K8S_NODE_NAME"
+        valueFrom:
+          fieldRef:
+            fieldPath: "spec.nodeName"
+      - name: "HOST_IP"
+        valueFrom:
+          fieldRef:
+            fieldPath: "status.hostIP"
+      - name: "HOST_NAME"
+        valueFrom:
+          fieldRef:
+            fieldPath: "spec.nodeName"
+      - name: "K8S_NAMESPACE"
+        valueFrom:
+          fieldRef:
+            fieldPath: "metadata.namespace"
+    command:
+      - "/awscollector"
+      - "--config=/conf/adot-config.yaml"
+    resources:
+      limits:
+        cpu: "200m"
+        memory: "200Mi"
+      requests:
+        cpu: "200m"
+        memory: "200Mi"
+    volumes:
+      - configMap:
+          name: "adot-conf"
+          items:
+            - key: "adot-config"
+              path: "adot-config.yaml"
+        name: "adot-config-vol"
+      - name: "rootfs"
+        hostPath:
+          path: "/"
+      - name: "dockersock"
+        hostPath:
+          path: "/var/run/docker.sock"
+      - name: "varlibdocker"
+        hostPath:
+          path: "/var/lib/docker"
+      - name: "sys"
+        hostPath:
+          path: "/sys"
+      - name: "devdisk"
+        hostPath:
+          path: "/dev/disk/"
+    volumeMounts:
+      - name: "rootfs"
+        mountPath: "/rootfs"
+        readOnly: true
+      - name: "dockersock"
+        mountPath: "/var/run/docker.sock"
+        readOnly: true
+      - name: "varlibdocker"
+        mountPath: "/var/lib/docker"
+        readOnly: true
+      - name: "sys"
+        mountPath: "/sys"
+        readOnly: true
+      - name: "devdisk"
+        mountPath: "/dev/disk"
+        readOnly: true
+      - name: "adot-config-vol"
+        mountPath: "/conf"
+    extensions:
+      healthCheck: ""
+    receivers:
+      collectionInterval: ""
+      containerOrchestrator: ""
+      addServiceAsAttribute: ""
+      preferFullPodName: ""
+    processors:
+      timeout: 60s
+    exporters:
+      datadog:
+        api:
+          key: "<DATADOG_API_KEY>"
+          site: datadoghq.com
+        metrics:
+          resource_attributes_as_tags: true
+        use_resource_metadata: true
+      
+    service:
+      metrics:
+        receivers: ["awscontainerinsightreceiver"]
+        processors: ["batch/metrics", "resourcedetection/k8s"]
+        exporters: ["datadog"]
+      extensions: ["health_check"]
+
+  sidecar:
+    enabled: false
+    name: "adot-sidecar"
+    namespace: "adot-sidecar-namespace"
+    namespaceOverride: ""
+    regionS3: ""
+    replicas: 1
+    image:
+      name: ""
+      repository: ""
+      tag: ""
+      pullPolicy: ""
+    resources:
+      limits:
+        cpu: "256m"
+        memory: "512Mi"
+      requests:
+        cpu: "32m"
+        memory: "24Mi"


### PR DESCRIPTION
### What does this PR do?

Add a new Helm chart to showcase how to use the Datadog exporter to send metrics generated by the awscontainerinsights receiver to Datadog.

The Helm chart is based on the adot-exporter-for-eks-on-ec2 Helm chart, with updated instructions and configuration.

It defines the same Kubernetes objects, with the addition of a `Secret` to store the Datadog API key.
