### PR TITLE
Helm chart for sending EKS on EC2 metrics to AMP

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -14,30 +14,75 @@ data:
       health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
     receivers:
       awscontainerinsightreceiver:
-        collection_interval: {{ .Values.adotCollector.daemonSet.receivers.collectionInterval }}
-        container_orchestrator: {{ .Values.adotCollector.daemonSet.receivers.containerOrchestrator }}
-        add_service_as_attribute: {{ .Values.adotCollector.daemonSet.receivers.addServiceAsAttribute }}
-        prefer_full_pod_name: {{ .Values.adotCollector.daemonSet.receivers.preferFullPodName }}
+        collection_interval: {{ .Values.adotCollector.daemonSet.cwreceivers.collectionInterval }}
+        container_orchestrator: {{ .Values.adotCollector.daemonSet.cwreceivers.containerOrchestrator }}
+        add_service_as_attribute: {{ .Values.adotCollector.daemonSet.cwreceivers.addServiceAsAttribute }}
+        prefer_full_pod_name: {{ .Values.adotCollector.daemonSet.cwreceivers.preferFullPodName }}
+      prometheus:
+        config:
+          global:
+            scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval}}
+            scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout}}
+          scrape_configs:
+            - job_name: 'storefront'
+              sample_limit: 10000
+              metrics_path: /metrics
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  regex: (.+)
+                  target_label: __metrics_path__
+                - source_labels: [__address__]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: EKS_Namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: EKS_PodName
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  action: replace
+                  target_label: EKS_Container
     processors:
       batch/metrics:
-        timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
+        timeout: {{ .Values.adotCollector.daemonSet.cwprocessors.timeout }}
     exporters:
       awsemf:
-        namespace: {{ .Values.adotCollector.daemonSet.exporters.namespace }}
+        namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}
         log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/performance'
-        log_stream_name: {{ .Values.adotCollector.daemonSet.exporters.logStreamName }}
+        log_stream_name: {{ .Values.adotCollector.daemonSet.cwexporters.logStreamName }}
         resource_to_telemetry_conversion:
-          enabled: {{ .Values.adotCollector.daemonSet.exporters.enabled }}
-        dimension_rollup_option: {{ .Values.adotCollector.daemonSet.exporters.dimensionRollupOption }}
-        parse_json_encoded_attr_values: {{- range .Values.adotCollector.daemonSet.exporters.parseJsonEncodedAttrValues }}
+          enabled: {{ .Values.adotCollector.daemonSet.cwexporters.enabled }}
+        dimension_rollup_option: {{ .Values.adotCollector.daemonSet.cwexporters.dimensionRollupOption }}
+        parse_json_encoded_attr_values: {{- range .Values.adotCollector.daemonSet.cwexporters.parseJsonEncodedAttrValues }}
         - {{.}}{{- end }}
         metric_declarations:
           {{ .Values.adotCollector.daemonSet.metricDeclarations | nindent 10 }}
+      awsprometheusremotewrite:
+        endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint}}
+        aws_auth:
+          region: {{ .Values.adotCollector.daemonSet.ampexporters.region}}
+          service: {{ .Values.adotCollector.daemonSet.ampexporters.service}}
+        
     service:
       pipelines:
         metrics:
-          receivers: {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
+          receivers: {{- if .Values.adotCollector.daemonSet.cwEnabled and .Values.adotCollector.daemonSet.ampEnabled}}
+          {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
           - {{.}}{{- end }}
+          {{- else if eq Values.adotCollector.daemonSet.ampEnabled False}}
+          {{- range .Values.adotCollector.daemonSet.service.metrics.receivers}}
+          {{- end}}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
           - {{.}}{{- end }}
           exporters: {{- range .Values.adotCollector.daemonSet.service.metrics.exporters }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -42,11 +42,11 @@ data:
       awsprometheusremotewrite:
         namespace: {{ .Values.adotCollector.daemonSet.ampexporters.namespace }}
         endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint }}
-        # resource_to_telemetry_conversion: 
-        #   enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetotel }}
+        resource_to_telemetry_conversion: 
+          enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetotel }}
         aws_auth:
           region: {{ .Values.adotCollector.daemonSet.ampexporters.region }}
-          service: {{ .Values.adotCollector.daemonSet.ampexporters.service }}
+          service: aps
         
     service:
       pipelines:
@@ -55,14 +55,8 @@ data:
           - {{.}} {{- end }}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
           - {{.}} {{- end }}
-          {{- if eq .Values.adotCollector.daemonSet.cwEnabled false }}
-          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.ampexporter }}
-          {{- else if eq .Values.adotCollector.daemonSet.ampEnabled false }}
-          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.cwexporter }}
-          {{- else }}
           exporters: {{- range .Values.adotCollector.daemonSet.service.metrics.exporters }}
           - {{.}} {{- end }}
-          {{- end}}
       extensions: {{- range .Values.adotCollector.daemonSet.service.extensions }}
       - {{.}} {{- end }}
 {{- end }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -53,6 +53,7 @@ data:
                 - source_labels: [__meta_kubernetes_pod_container_name]
                   action: replace
                   target_label: EKS_Container
+
     processors:
       batch/metrics:
         timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
@@ -77,12 +78,12 @@ data:
     service:
       pipelines:
         metrics:
-          {{- if eq .Values.adotCollector.daemonSet.cwEnabled False }}
-          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.ampreceiver}}
+          {{- if eq .Values.adotCollector.daemonSet.cwEnabled false }}
+          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.ampreceiver }}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
           - {{.}} {{- end }}
           exporters: {{ .Values.adotCollector.daemonSet.service.metrics.ampexporter }}
-          {{- else if eq Values.adotCollector.daemonSet.ampEnabled False }}
+          {{- else if eq .Values.adotCollector.daemonSet.ampEnabled false }}
           receivers: {{ .Values.adotCollector.daemonSet.service.metrics.cwreceiver }}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
           - {{.}} {{- end }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -23,7 +23,8 @@ data:
           global:
             scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval }}
             scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout }}
-          scrape_configs: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeConfigs | nindent 10 }}
+          scrape_configs: 
+            {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeConfigs | nindent 12 }}
     processors:
       batch/metrics:
         timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -21,38 +21,9 @@ data:
       prometheus:
         config:
           global:
-            scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval}}
-            scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout}}
-          scrape_configs:
-            - job_name: 'storefront'
-              sample_limit: 10000
-              metrics_path: /metrics
-              kubernetes_sd_configs:
-                - role: pod
-              relabel_configs:
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-                  action: keep
-                  regex: true
-                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-                  action: replace
-                  regex: (.+)
-                  target_label: __metrics_path__
-                - source_labels: [__address__]
-                  action: replace
-                  regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
-                  target_label: __address__
-                - action: labelmap
-                  regex: __meta_kubernetes_pod_label_(.+)
-                - source_labels: [__meta_kubernetes_namespace]
-                  action: replace
-                  target_label: EKS_Namespace
-                - source_labels: [__meta_kubernetes_pod_name]
-                  action: replace
-                  target_label: EKS_PodName
-                - source_labels: [__meta_kubernetes_pod_container_name]
-                  action: replace
-                  target_label: EKS_Container
+            scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval }}
+            scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout }}
+          scrape_configs: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeConfigs | nindent 10 }}
     processors:
       batch/metrics:
         timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -55,7 +55,7 @@ data:
                   target_label: EKS_Container
     processors:
       batch/metrics:
-        timeout: {{ .Values.adotCollector.daemonSet.cwprocessors.timeout }}
+        timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
     exporters:
       awsemf:
         namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}
@@ -77,16 +77,24 @@ data:
     service:
       pipelines:
         metrics:
-          receivers: {{- if .Values.adotCollector.daemonSet.cwEnabled and .Values.adotCollector.daemonSet.ampEnabled}}
-          {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
-          - {{.}}{{- end }}
-          {{- else if eq Values.adotCollector.daemonSet.ampEnabled False}}
-          {{- range .Values.adotCollector.daemonSet.service.metrics.receivers}}
-          {{- end}}
+          {{- if eq .Values.adotCollector.daemonSet.cwEnabled False }}
+          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.ampreceiver}}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
-          - {{.}}{{- end }}
+          - {{.}} {{- end }}
+          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.ampexporter }}
+          {{- else if eq Values.adotCollector.daemonSet.ampEnabled False }}
+          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.cwreceiver }}
+          processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
+          - {{.}} {{- end }}
+          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.cwexporter }}
+          {{- else }}
+          receivers: {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
+          - {{.}} {{- end }}
+          processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
+          - {{.}} {{- end }}
           exporters: {{- range .Values.adotCollector.daemonSet.service.metrics.exporters }}
-          - {{.}}{{- end }}
+          - {{.}} {{- end }}
+          {{- end}}
       extensions: {{- range .Values.adotCollector.daemonSet.service.extensions }}
-      - {{.}}{{- end }}
+      - {{.}} {{- end }}
 {{- end }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     app: {{ .Values.adotCollector.daemonSet.configMap.app }}
     component: {{ .Values.adotCollector.daemonSet.configMap.component }}
 data:
-  adot-config: |
+  adot-config:  |
     extensions:
       health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
     receivers:
@@ -53,7 +53,6 @@ data:
                 - source_labels: [__meta_kubernetes_pod_container_name]
                   action: replace
                   target_label: EKS_Container
-
     processors:
       batch/metrics:
         timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
@@ -70,29 +69,26 @@ data:
         metric_declarations:
           {{ .Values.adotCollector.daemonSet.metricDeclarations | nindent 10 }}
       awsprometheusremotewrite:
-        endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint}}
+        namespace: {{ .Values.adotCollector.daemonSet.ampexporters.namespace }}
+        endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint }}
+        # resource_to_telemetry_conversion: 
+        #   enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetotel }}
         aws_auth:
-          region: {{ .Values.adotCollector.daemonSet.ampexporters.region}}
-          service: {{ .Values.adotCollector.daemonSet.ampexporters.service}}
+          region: {{ .Values.adotCollector.daemonSet.ampexporters.region }}
+          service: {{ .Values.adotCollector.daemonSet.ampexporters.service }}
         
     service:
       pipelines:
         metrics:
-          {{- if eq .Values.adotCollector.daemonSet.cwEnabled false }}
-          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.ampreceiver }}
-          processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
-          - {{.}} {{- end }}
-          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.ampexporter }}
-          {{- else if eq .Values.adotCollector.daemonSet.ampEnabled false }}
-          receivers: {{ .Values.adotCollector.daemonSet.service.metrics.cwreceiver }}
-          processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
-          - {{.}} {{- end }}
-          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.cwexporter }}
-          {{- else }}
           receivers: {{- range .Values.adotCollector.daemonSet.service.metrics.receivers }}
           - {{.}} {{- end }}
           processors: {{- range .Values.adotCollector.daemonSet.service.metrics.processors }}
           - {{.}} {{- end }}
+          {{- if eq .Values.adotCollector.daemonSet.cwEnabled false }}
+          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.ampexporter }}
+          {{- else if eq .Values.adotCollector.daemonSet.ampEnabled false }}
+          exporters: {{ .Values.adotCollector.daemonSet.service.metrics.cwexporter }}
+          {{- else }}
           exporters: {{- range .Values.adotCollector.daemonSet.service.metrics.exporters }}
           - {{.}} {{- end }}
           {{- end}}

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -9,7 +9,7 @@ serviceAccount:
   annotations: {}
   name: ""
 fluentbit:
-  enabled: false
+  enabled: true
   namespaceOverride: ""
   name: "fluent-bit"
   configName: "fluent-bit-config"
@@ -180,7 +180,7 @@ adotCollector:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
     namespace: "amazon-metrics"
-    cwEnabled: false
+    cwEnabled: true
     ampEnabled: true
     namespaceOverride: ""
     serviceAccount:
@@ -341,7 +341,7 @@ adotCollector:
       scrapeInterval: 15s
       scrapeTimeout: 10s
       scrapeConfigs: |
-            - job_name: 'storefront'
+            - job_name: 'k8s_metrics_scrape'
               sample_limit: 10000
               metrics_path: /metrics
               kubernetes_sd_configs:
@@ -376,9 +376,9 @@ adotCollector:
 
     ampexporters:
       namespaces: "AMP data"
-      endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-e8aabeb8-3f57-4fd2-945e-d0453dbefb74/api/v1/remote_write"
+      endpoint: "[Add Prometheus workspace remote write URL]"
       resourcetotel: true
-      region: "us-west-2"
+      region: "[Add AWS Region]"
       service: "aps"
     service:
       metrics:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -9,7 +9,7 @@ serviceAccount:
   annotations: {}
   name: ""
 fluentbit:
-  enabled: true
+  enabled: false
   namespaceOverride: ""
   name: "fluent-bit"
   configName: "fluent-bit-config"
@@ -180,7 +180,7 @@ adotCollector:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
     namespace: "amazon-metrics"
-    cwEnabled: true
+    cwEnabled: false
     ampEnabled: true
     namespaceOverride: ""
     serviceAccount:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -377,7 +377,7 @@ adotCollector:
     ampexporters:
       namespaces: ""
       endpoint: ""
-      resourcetotel: true
+      resourcetotel: false
       region: ""
     service:
       metrics:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -148,7 +148,7 @@ fluentbit:
 
 fargateLog:
   enabled: false
-  name: "aws-logging"
+  name: "amazon-logging"
   namespace: "aws-observability"
   awsObservability: "enabled"
   outputConf:
@@ -179,7 +179,7 @@ adotCollector:
   daemonSet:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
-    namespace: "amzn-metrics"
+    namespace: "amazon-metrics"
     cwEnabled: true
     ampEnabled: true
     namespaceOverride: ""
@@ -202,6 +202,10 @@ adotCollector:
         valueFrom:
           fieldRef:
             fieldPath: "status.hostIP"
+      - name: "K8S_POD_NAME"
+        valueFrom:
+          fieldRef:
+            fieldPath: "metadata.name"
       - name: "HOST_NAME"
         valueFrom:
           fieldRef:
@@ -357,12 +361,15 @@ adotCollector:
                   target_label: __address__
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_pod_node_name]
+                  action: keep
+                  regex: K8S_NODE_NAME
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
-                  target_label: EKS_Namespace
+                  target_label: K8S_NAMESPACE
                 - source_labels: [__meta_kubernetes_pod_name]
                   action: replace
-                  target_label: EKS_PodName
+                  target_label: K8S_POD_NAME
                 - source_labels: [__meta_kubernetes_pod_container_name]
                   action: replace
                   target_label: EKS_Container

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -267,7 +267,7 @@ adotCollector:
       containerOrchestrator: ""
       addServiceAsAttribute: ""
       preferFullPodName: ""
-    cwprocessors:
+    processors:
       timeout: 60s
     cwexporters:
       namespace: "ContainerInsights"
@@ -343,8 +343,12 @@ adotCollector:
     service:
       metrics:
         receivers: ["awscontainerinsightreceiver", "prometheus"]
+        cwreceiver: "awscontainerinsightreceiver"
+        ampreceiver: "prometheus"
         processors: ["batch/metrics"]
         exporters: ["awsemf", "awsprometheusremotewrite"]
+        cwexporter: "awsemf"
+        ampexporter: "awsprometheusremotewrite"
       extensions: ["health_check"]
 
   sidecar:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -185,8 +185,6 @@ adotCollector:
     createNamespace: true
     namespace: "amazon-metrics"
     namespaceOverride: ""
-    cwEnabled: true
-    ampEnabled: true
     serviceAccount:
       create: true
       name: "adot-collector-sa"

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -185,7 +185,7 @@ adotCollector:
     namespaceOverride: ""
     serviceAccount:
       create: true
-      name: "adot-collector"
+      name: "adot-collector-sa"
     clusterRoleName: "adot-collector-role"
     clusterRoleBindingName: "adot-collector-role-binding"
     configMap:
@@ -357,13 +357,13 @@ adotCollector:
                 - source_labels: [__address__]
                   action: replace
                   regex: ([^:]+)(?::\d+)?;(\d+)
-                  replacement: $1:$2
+                  replacement: $$1:$$2
                   target_label: __address__
                 - action: labelmap
                   regex: __meta_kubernetes_pod_label_(.+)
                 - source_labels: [__meta_kubernetes_pod_node_name]
                   action: keep
-                  regex: K8S_NODE_NAME
+                  regex: ${K8S_NODE_NAME}
                 - source_labels: [__meta_kubernetes_namespace]
                   action: replace
                   target_label: K8S_NAMESPACE

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -180,12 +180,12 @@ adotCollector:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
     namespace: "amzn-metrics"
-    cloudWatchEnabled: true
+    cwEnabled: true
     ampEnabled: true
     namespaceOverride: ""
     serviceAccount:
       create: true
-      name: "adot-collector-sa"
+      name: "adot-collector"
     clusterRoleName: "adot-collector-role"
     clusterRoleBindingName: "adot-collector-role-binding"
     configMap:
@@ -337,7 +337,9 @@ adotCollector:
       scrapeInterval: 15s
       scrapeTimeout: 10s
     ampexporters:
-      endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-d18949af-dfec-4d07-b013-0cab497a176b/api/v1/remote_write"
+      namespaces: "AMP data"
+      endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-e8aabeb8-3f57-4fd2-945e-d0453dbefb74/api/v1/remote_write"
+      resourcetotel: true
       region: "us-west-2"
       service: "aps"
     service:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -334,11 +334,11 @@ adotCollector:
         metric_name_selectors:
           - namespace_number_of_running_pods
     ampreceivers:
-      scrapeInterval: 15
-      scrapeTimeout: 10
+      scrapeInterval: 15s
+      scrapeTimeout: 10s
     ampexporters:
-      endpoint: ""
-      region: ""
+      endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-d18949af-dfec-4d07-b013-0cab497a176b/api/v1/remote_write"
+      region: "us-west-2"
       service: "aps"
     service:
       metrics:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -336,6 +336,37 @@ adotCollector:
     ampreceivers:
       scrapeInterval: 15s
       scrapeTimeout: 10s
+      scrapeConfigs: |
+            - job_name: 'storefront'
+              sample_limit: 10000
+              metrics_path: /metrics
+              kubernetes_sd_configs:
+                - role: pod
+              relabel_configs:
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+                  action: keep
+                  regex: true
+                - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+                  action: replace
+                  regex: (.+)
+                  target_label: __metrics_path__
+                - source_labels: [__address__]
+                  action: replace
+                  regex: ([^:]+)(?::\d+)?;(\d+)
+                  replacement: $1:$2
+                  target_label: __address__
+                - action: labelmap
+                  regex: __meta_kubernetes_pod_label_(.+)
+                - source_labels: [__meta_kubernetes_namespace]
+                  action: replace
+                  target_label: EKS_Namespace
+                - source_labels: [__meta_kubernetes_pod_name]
+                  action: replace
+                  target_label: EKS_PodName
+                - source_labels: [__meta_kubernetes_pod_container_name]
+                  action: replace
+                  target_label: EKS_Container
+
     ampexporters:
       namespaces: "AMP data"
       endpoint: "https://aps-workspaces.us-west-2.amazonaws.com/workspaces/ws-e8aabeb8-3f57-4fd2-945e-d0453dbefb74/api/v1/remote_write"

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -375,20 +375,15 @@ adotCollector:
                   target_label: EKS_Container
 
     ampexporters:
-      namespaces: "AMP data"
-      endpoint: "[Add Prometheus workspace remote write URL]"
+      namespaces: ""
+      endpoint: ""
       resourcetotel: true
-      region: "[Add AWS Region]"
-      service: "aps"
+      region: ""
     service:
       metrics:
         receivers: ["awscontainerinsightreceiver", "prometheus"]
-        cwreceiver: "awscontainerinsightreceiver"
-        ampreceiver: "prometheus"
         processors: ["batch/metrics"]
         exporters: ["awsemf", "awsprometheusremotewrite"]
-        cwexporter: "awsemf"
-        ampexporter: "awsprometheusremotewrite"
       extensions: ["health_check"]
 
   sidecar:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -179,7 +179,9 @@ adotCollector:
   daemonSet:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
-    namespace: "amzn-cloudwatch-metrics"
+    namespace: "amzn-metrics"
+    cloudWatchEnabled: true
+    ampEnabled: true
     namespaceOverride: ""
     serviceAccount:
       create: true
@@ -260,14 +262,14 @@ adotCollector:
         mountPath: "/conf"
     extensions:
       healthCheck: ""
-    receivers:
+    cwreceivers:
       collectionInterval: ""
       containerOrchestrator: ""
       addServiceAsAttribute: ""
       preferFullPodName: ""
-    processors:
+    cwprocessors:
       timeout: 60s
-    exporters:
+    cwexporters:
       namespace: "ContainerInsights"
       logGroupName: ""
       logStreamName: "InputNodeName"
@@ -331,11 +333,18 @@ adotCollector:
       - dimensions: [[Namespace, ClusterName], [ClusterName]]
         metric_name_selectors:
           - namespace_number_of_running_pods
+    ampreceivers:
+      scrapeInterval: 15
+      scrapeTimeout: 10
+    ampexporters:
+      endpoint: ""
+      region: ""
+      service: "aps"
     service:
       metrics:
-        receivers: ["awscontainerinsightreceiver"]
+        receivers: ["awscontainerinsightreceiver", "prometheus"]
         processors: ["batch/metrics"]
-        exporters: ["awsemf"]
+        exporters: ["awsemf", "awsprometheusremotewrite"]
       extensions: ["health_check"]
 
   sidecar:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -384,9 +384,9 @@ adotCollector:
       region: ""
     service:
       metrics:
-        receivers: ["awscontainerinsightreceiver", "prometheus"]
+        receivers: ["prometheus"]
         processors: ["batch/metrics"]
-        exporters: ["awsemf", "awsprometheusremotewrite"]
+        exporters: ["awsprometheusremotewrite"]
       extensions: ["health_check"]
 
   sidecar:


### PR DESCRIPTION
Changes made to the existing Helm chart to support sending metric to AMP. Opened a PR. Abstraction of the scrape configs for the Prometheus operator is still being worked on. Manual end-to-end Testing is complete. Sources used for the code:
- [Getting started guide](https://quip-amazon.com/Ca0VA9hMkKSf/Third-Draft-Getting-Started-with-the-AWS-Distro-for-OpenTelemetry-EKS-Add-On-preview)
- [Helm chart flow control](https://helm.sh/docs/chart_template_guide/control_structures/)