### PR TITLE
adot collector service account, cluster role, and namespace updates

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
@@ -22,6 +22,6 @@ rules:
     verbs: ["create", "get"]
   - apiGroups: [""]
     resources: ["configmaps"]
-    resourceNames: ["adot-container-insight-clusterleader"]
+    resourceNames: ["adot-container-insight-clusterleader", "otel-container-insight-clusterleader"]
     verbs: ["get","update"]
 {{- end }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/namespace.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.adotCollector.daemonSet.enabled }}
+{{- if and .Values.adotCollector.daemonSet.enabled .Values.adotCollector.daemonSet.createNamespace }}
 # Specify namespace for ADOT Collector as a DaemonSet.
 apiVersion: v1
 kind: Namespace

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
@@ -1,8 +1,12 @@
-{{- if .Values.adotCollector.daemonSet.enabled }}
+{{- if .Values.adotCollector.daemonSet.enabled -}}
 # Service account provides identity information for a user to be able to authenticate processes running in a pod.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.adotCollector.daemonSet.serviceAccount.name }}
   namespace: {{ include "adotCollector.daemonSet.namespace" . }}
-{{- end }}
+  {{- with .Values.adotCollector.daemonSet.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -588,6 +588,9 @@
                                 },
                                 "name": {
                                     "type": "string"
+                                },
+                                "annotations": {
+                                    "type": "object"
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -574,6 +574,9 @@
                         "daemonSetName": {
                             "type": "string"
                         },
+                        "createNamespace": {
+                            "type": "boolean"
+                        },
                         "namespace": {
                             "type": "string"
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -179,11 +179,13 @@ adotCollector:
   daemonSet:
     enabled: true
     daemonSetName: "adot-collector-daemonset"
+    createNamespace: true
     namespace: "amzn-cloudwatch-metrics"
     namespaceOverride: ""
     serviceAccount:
       create: true
       name: "adot-collector-sa"
+      annotations: {}
     clusterRoleName: "adot-collector-role"
     clusterRoleBindingName: "adot-collector-role-binding"
     configMap:


### PR DESCRIPTION
Added the following:
- Added variables for adot service account annotations. I need this for using IRSA.
- Added permission to the resource `otel-container-insight-clusterleader` on the atol cluster role since the logs were erroring without it updating the leader configmap. I'm not sure if `adot-container-insight-clusterleader` is a typo or a separate resource so I left it in. This was the error before the clusterrole change: ```
1 leaderelection.go:367] Failed to update lock: configmaps "otel-container-insight-clusterleader" is forbidden: User "system:serviceaccount:amzn-cloudwatch-metrics:adot-collector-sa" cannot update resource "configmaps" in API group "" in the namespace "amzn-cloudwatch-metrics"```
- Added a flag to not create the namespace. Needed for my use case because helm will force create the namespace.


My use case is deploying this helm chart just for the adot collector for metrics. I was installing locally using the following command:
```
helm install --create-namespace --namespace $NAMESPACE \
  --set clusterName=$CLUSTERNAME \
  --set awsRegion=$REGION \
  --set adotCollector.daemonSet.createNamespace=false \
  --set adotCollector.daemonSet.namespace=$NAMESPACE \
  --set adotCollector.daemonSet.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=$IAMROLEARN \
  --set fluentbit.enabled=false \
  testing ./adot-exporter-for-eks-on-ec2-0.1.0.tgz
```