### PR TITLE
fix: unable to use docker image from a private registry

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -63,7 +63,7 @@
                     "properties": {
                         "repository": {
                             "type": "string",
-                            "pattern": "^[/a-z0-9-_]+$"
+                            "pattern": "^[a-z0-9\\.\\-_\\/]*$"
                         },
                         "tag": {
                             "type": "string"
@@ -550,7 +550,7 @@
                         },
                         "repository": {
                             "type": "string",
-                            "pattern": "^[/a-z0-9-_]+$"
+                            "pattern": "^[a-z0-9\\.\\-_\\/]*$"
                         },
                         "tag": {
                             "type": "string"
@@ -1088,7 +1088,7 @@
                                 },
                                 "repository": {
                                     "type": "string",
-                                    "pattern": "(^$|^[/a-z0-9-_]+)$"
+                                    "pattern": "^[a-z0-9\\.\\-_\\/]*$"
                                 },
                                 "tag": {
                                     "type": "string"


### PR DESCRIPTION
fix: unable to pull an image from a private registry or public ECR:

when I try to pull the image from a private registry or public ECR:
```bash
helm install \
  adot-exporter-for-eks-on-ec2 \
  aws-observability/adot-exporter-for-eks-on-ec2 \
  --set fluentbit.enabled=true \
  --set adotCollector.daemonSet.enabled=true \
  --set adotCollector.sidecar.enabled=true \
  --set fluentbi.image.repository="public.ecr.aws/aws-observability/aws-for-fluent-bit" \
  --set adotCollector.image.repository="public.ecr.aws/aws-observability/aws-otel-collector" \
  --set adotCollector.sidecar.image.repository="public.ecr.aws/aws-observability/aws-otel-collector"
```
I get this error:
```
Error: INSTALLATION FAILED: values don't meet the specifications of the schema(s) in the following chart(s):
adot-exporter-for-eks-on-ec2:
- adotCollector.image.repository: Does not match pattern '^[/a-z0-9-_]+$'
- adotCollector.sidecar.image.repository: Does not match pattern '(^$|^[/a-z0-9-_]+)$
```

`By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.`