### PR TITLE
feat: add fluent-bit service account annotations

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/serviceaccount.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/serviceaccount.yaml
@@ -3,6 +3,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.fluentbit.name }}
+  name: {{ .Values.fluentbit.serviceAccount.name }}
   namespace: {{ include "aws-for-fluent-bit.namespace" . }}
-{{- end }}
+  {{- with .Values.fluentbit.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -54,6 +54,17 @@
                 "namespace": {
                     "type": "string"
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "annotations": {
+                            "type": "object"
+                        }
+                    }
+                },
                 "image": {
                     "type": "object",
                     "required": [

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -14,6 +14,9 @@ fluentbit:
   name: "fluent-bit"
   configName: "fluent-bit-config"
   namespace: "amazon-cloudwatch"
+  serviceAccount:
+    name: "fluent-bit"
+    annotations: {}
   imdsVersion: v1
   image:
     repository: "amazon/aws-for-fluent-bit"


### PR DESCRIPTION
This pull request will enable:
 * control of service account name for fluent bit 
 * association with IAM role (IRSA) [AWS Offciale documentation](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)

by adding variables for fluentbit service account annotations:
```yaml
fluentbit:
  serviceAccount:
    name: "fluent-bit"
    annotations: {}
```
example:
```yaml
fluentbit:
  serviceAccount:
    name: "fluent-bit"
    annotations:
      eks.amazonaws.com/role-arn: <IAM role arn>
```

My use case is associating fluent bit service account with IAM role with trust relationship:
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::<account id>:oidc-provider/oidc.eks.<aws region>.amazonaws.com/id/<oidc id>"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "ForAnyValue:StringEquals": {
                    "oidc.eks.<aws region>.amazonaws.com/id/<oidc id>:sub": [
                        "system:serviceaccount:<fluent bit namespace>:<fluent bit service account name>"
                    ]
                }
            }
        }
    ]
}
```
my local test:
```bash
helm install \
  local charts/adot-exporter-for-eks-on-ec2 \
  --set clusterName=$CLUSTERNAME \
  --set awsRegion=$REGION \
  --set fluentbit.enabled=true \
  --set fluentbit.serviceAccount.name=$FLUENTBIT_SA_NAME \
  --set fluentbit.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=$FLUENTBIT_SA_IAM_ROLE_ARN 
```