### PR TITLE
feat: cloudwatch logs retention days

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/configmap.yaml
@@ -88,6 +88,7 @@ data:
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/application
         log_stream_prefix   ${HOST_NAME}-
         auto_create_group   true
+        {{ if .Values.fluentbit.output.applicationLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.applicationLog.log_retention.days | default 7 }}{{ end }}  
         extra_user_agent    container-insights
 
   dataplane-log.conf: |
@@ -135,6 +136,7 @@ data:
         region              {{ .Values.awsRegion }}
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/dataplane
         log_stream_prefix   ${HOST_NAME}-
+        {{ if .Values.fluentbit.output.dataplaneLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.dataplaneLog.log_retention.days | default 7 }}{{ end }}
         auto_create_group   true
         extra_user_agent    container-insights
     
@@ -183,6 +185,7 @@ data:
         region              {{ .Values.awsRegion }}
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/host
         log_stream_prefix   ${HOST_NAME}.
+        {{ if .Values.fluentbit.output.hostLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.hostLog.log_retention.days | default 7 }}{{ end }}
         auto_create_group   true
         extra_user_agent    container-insights
 

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -290,6 +290,53 @@
                         }
                     }
                 },
+                "output": {
+                    "type": "object",
+                    "properties": {
+                        "applicationLog": {
+                            "type": "object",
+                            "properties": {
+                                "log_retention": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "days": {
+                                        "type": "integer",
+                                        "enum": [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+                                    }
+                                }
+                            }
+                        },
+                        "dataplaneLog": {
+                            "type": "object",
+                            "properties": {
+                                "log_retention": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "days": {
+                                        "type": "integer",
+                                        "enum": [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+                                    }
+                                }
+                            }
+                        },
+                        "hostLog": {
+                            "type": "object",
+                            "properties": {
+                                "log_retention": {
+                                    "enabled": {
+                                        "type": "boolean"
+                                    },
+                                    "days": {
+                                        "type": "integer",
+                                        "enum": [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "kubernetesFilter": {
                     "type": "object",
                     "properties": {

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -83,6 +83,19 @@ fluentbit:
       memBufLimit: "5MB"
       skipLongLines: "On"
       refreshInterval: 10
+  output:
+    applicationLog:
+      log_retention:
+        enabled: false
+        days: 30
+    dataplaneLog:
+      log_retention:
+        enabled: false
+        days: 30
+    hostLog:
+      log_retention:
+        enabled: false
+        days: 30
   kubernetesFilter:
     match: "application.*"
     kubeURL: "https://kubernetes.default.svc:443"


### PR DESCRIPTION
This pull request will enable:
 * cloudwatch logs log retention for:
 * * application
 * * dataplane
 * * host

By default: cloudwatch logs retention will be __Never expire__ (as current configuration)

by adding variables to activate cloudwatch log retention :
```yaml
fluentbit:
  output:
    applicationLog:
      log_retention:
        enabled: true
        days: 30
    dataplaneLog:
      log_retention:
        enabled: true
        days: 30
    hostLog:
      log_retention:
        enabled: true
        days: 30
```
my local test:
```bash
helm install \
  local charts/adot-exporter-for-eks-on-ec2 \
  --set clusterName=$CLUSTERNAME \
  --set awsRegion=$REGION \
  --set fluentbit.enabled=true \
  --set fluentbit.output.applicationLog.log_retention.enabled=true \
  --set fluentbit.output.applicationLog.log_retention.days=30
```