### PR TITLE
Removed CloudWatch agent specific INPUT section from FluentBit configmap.yaml and values.yaml file

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adot-exporter-for-eks-on-ec2
 description: A Helm chart for collecting metrics using ADOT Collector and logs using Fluent Bit to send to AWS monitoring services.
 type: application
-version: 0.4.0
+version: 0.5.0
 appVersion: "0.17.0"
 kubeVersion: ">=1.16.0-0"
 maintainers:

--- a/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/configmap.yaml
@@ -55,20 +55,6 @@ data:
         Refresh_Interval    {{ .Values.fluentbit.input.applicationLog.refreshInterval }}
         Read_from_Head      {{ .Values.fluentbit.env.readFromHead }}
 
-    [INPUT]
-        Name                tail
-        Tag                 {{ .Values.fluentbit.input.applicationLog.tag }}
-        Path                {{ .Values.fluentbit.input.applicationLog.cloudwatchAgent.path }}
-        Docker_Mode         {{ .Values.fluentbit.input.applicationLog.dockerMode }}
-        Docker_Mode_Flush   {{ .Values.fluentbit.input.applicationLog.dockerModeFlush }}
-        Docker_Mode_Parser  {{ .Values.fluentbit.input.applicationLog.cloudwatchAgent.dockerModeParser }}
-        Parser              {{ .Values.fluentbit.input.applicationLog.parser }}
-        DB                  {{ .Values.fluentbit.input.applicationLog.cloudwatchAgent.db }}
-        Mem_Buf_Limit       {{ .Values.fluentbit.input.applicationLog.cloudwatchAgent.memBufLimit }}
-        Skip_Long_Lines     {{ .Values.fluentbit.input.applicationLog.skipLongLines }}
-        Refresh_Interval    {{ .Values.fluentbit.input.applicationLog.refreshInterval }}
-        Read_from_Head      {{ .Values.fluentbit.env.readFromHead }}
-
     [FILTER]
         Name                kubernetes
         Match               {{ .Values.fluentbit.kubernetesFilter.match }}
@@ -88,7 +74,9 @@ data:
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/application
         log_stream_prefix   ${HOST_NAME}-
         auto_create_group   true
-        {{ if .Values.fluentbit.output.applicationLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.applicationLog.log_retention.days | default 7 }}{{ end }}  
+        {{ if .Values.fluentbit.output.applicationLog.log_retention.enabled }}
+        log_retention_days  {{ .Values.fluentbit.output.applicationLog.log_retention.days | default 7 }}
+        {{ end }}
         extra_user_agent    container-insights
 
   dataplane-log.conf: |
@@ -136,7 +124,9 @@ data:
         region              {{ .Values.awsRegion }}
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/dataplane
         log_stream_prefix   ${HOST_NAME}-
-        {{ if .Values.fluentbit.output.dataplaneLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.dataplaneLog.log_retention.days | default 7 }}{{ end }}
+        {{ if .Values.fluentbit.output.dataplaneLog.log_retention.enabled }}
+        log_retention_days  {{ .Values.fluentbit.output.dataplaneLog.log_retention.days | default 7 }}
+        {{ end }}
         auto_create_group   true
         extra_user_agent    container-insights
     
@@ -185,7 +175,9 @@ data:
         region              {{ .Values.awsRegion }}
         log_group_name      /aws/containerinsights/{{ .Values.clusterName }}/host
         log_stream_prefix   ${HOST_NAME}.
-        {{ if .Values.fluentbit.output.hostLog.log_retention.enabled }}log_retention_days  {{ .Values.fluentbit.output.hostLog.log_retention.days | default 7 }}{{ end }}
+        {{ if .Values.fluentbit.output.hostLog.log_retention.enabled }}
+        log_retention_days  {{ .Values.fluentbit.output.hostLog.log_retention.days | default 7 }}
+        {{ end }}
         auto_create_group   true
         extra_user_agent    container-insights
 

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -41,11 +41,6 @@ fluentbit:
         path: "/var/log/containers/fluent-bit*"
         db: "/var/fluent-bit/state/flb_log.db"
         memBufLimit: "5MB"
-      cloudwatchAgent:
-        path: "/var/log/containers/cloudwatch-agent*"
-        dockerModeParser: "cwagent_firstline"
-        db: "/var/fluent-bit/state/flb_cwagent.db"
-        memBufLimit: "5MB"
     dataplaneLog:
       systemd:
         tag: "dataplane.systemd.*"


### PR DESCRIPTION

**Description:** 
Removed CloudWatch agent specific INPUT section from FluentBit agent configmap.yaml and values.yaml files. 

**Link to tracking Issue:** #42 

**Testing:**

After removing the CloudWatch INPUT section in FluentBit agent configmap.yaml file, I created the chart locally using (`helm package`) command and deployed(using `helm install` command) the same successfully on EKS cluster. Verified the FluentBit pods status on EKS cluster, LogGroups existence, and the retention days in Amazon CloudWatch service. 

**Documentation:** 
<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
