### PR TITLE
Support add_full_pod_name_metric_label

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -19,6 +19,7 @@ data:
         container_orchestrator: {{ .Values.adotCollector.daemonSet.cwreceivers.containerOrchestrator }}
         add_service_as_attribute: {{ .Values.adotCollector.daemonSet.cwreceivers.addServiceAsAttribute }}
         prefer_full_pod_name: {{ .Values.adotCollector.daemonSet.cwreceivers.preferFullPodName }}
+        add_full_pod_name_metric_label: {{ .Values.adotCollector.daemonSet.cwreceivers.addFullPodNameMetricLabel }}
       prometheus:
         config:
           global:

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1030,6 +1030,9 @@
                                 },
                                 "preferFullPodName": {
                                     "type": "string"
+                                },
+                                "addFullPodNameMetricLabel": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -287,6 +287,7 @@ adotCollector:
       containerOrchestrator: ""
       addServiceAsAttribute: ""
       preferFullPodName: ""
+      addFullPodNameMetricLabel: ""
     processors:
       timeout: 60s
     cwexporters:


### PR DESCRIPTION
**Description:** Support add_full_pod_name_metric_label for awscontainerinsightreceiver reciver

The "FullPodName" attribute is the pod name including suffix. If false FullPodName label is not added. The default value is false

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/awscontainerinsightreceiver/README.md

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
