### PR TITLE
Update helm charts to use collector `v0.21.0` - Helm chart `v0.7.0` Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+#IDE
+.idea
+
+#build folder
+build/

--- a/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: adot-exporter-for-eks-on-ec2
 description: A Helm chart for collecting metrics using ADOT Collector and logs using Fluent Bit to send to AWS monitoring services.
 type: application
-version: 0.6.0
-appVersion: "0.18.0"
-kubeVersion: ">=1.16.0-0"
+version: 0.7.0
+appVersion: "0.19.0"
+kubeVersion: ">=1.19.0-0"
 maintainers:
   - name: Bryan Aguilar
     email: bryaag@amazon.com

--- a/charts/adot-exporter-for-eks-on-ec2/documentation/metrics_to_cloudwatch_amp.md
+++ b/charts/adot-exporter-for-eks-on-ec2/documentation/metrics_to_cloudwatch_amp.md
@@ -13,7 +13,7 @@ The above-mentioned deployment modes are explained in-detail in the following se
 
 ### Default Mode (Offload metrics to only Amazon Managed Prometheus)
 
- By default, the helm chart is configured to offload metrics data to the Amazon Managed Prometheus(AMP) workspace only. You need update the `values.yaml` file to add the Remote Write Endpoint URL and the region for your AMP workspace. By default, the region is set to `us-west-2`. By default, only the `prometheus` receiver and `awsprometheusremotewrite` exporter is included to be able to send metrics to AMP.
+ By default, the helm chart is configured to offload metrics data to the Amazon Managed Prometheus(AMP) workspace only. You need update the `values.yaml` file to add the Remote Write Endpoint URL and the region for your AMP workspace. By default, the region is set to `us-west-2`. By default, only the `prometheus` receiver and `prometheusremotewrite` exporter is included to be able to send metrics to AMP.
 
 ```console
 helm install \  
@@ -69,7 +69,7 @@ namespaces, they are successfully deployed.
 
 ### Offload metrics to both CloudWatch and Amazon Managed Prometheus(AMP)
 
-To send metrics to CloudWatch, you need to enable the CloudWatch pipeline. You can either update the `values.yaml` to change the values of the following variable `exporters` and then run the `helm install` command as above. Include both `prometheus`, `awscontainerinsightreceiver` as receivers, `awsemf`,`awsprometheusremotewrite` exporter to send metrics to both CloudWatch and AMP.
+To send metrics to CloudWatch, you need to enable the CloudWatch pipeline. You can either update the `values.yaml` to change the values of the following variable `exporters` and then run the `helm install` command as above. Include both `prometheus`, `awscontainerinsightreceiver` as receivers, `awsemf`,`prometheusremotewrite` exporter to send metrics to both CloudWatch and AMP.
 
 ```console
 helm install \  

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -14,7 +14,6 @@ data:
     extensions:
       health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
       sigv4auth:
-        service: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth.service }}
         region: {{ .Values.awsRegion }}
     receivers:
       awscontainerinsightreceiver:
@@ -51,7 +50,7 @@ data:
         resource_to_telemetry_conversion: 
           enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetootel }}
         auth:
-          authenticator: {{ .Values.adotCollector.daemonSet.service.extensions.sigv4auth }}
+          authenticator: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth }}
         
     service:
       pipelines:

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -50,7 +50,7 @@ data:
         resource_to_telemetry_conversion: 
           enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetootel }}
         auth:
-          authenticator: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth }}
+          authenticator: {{ .Values.adotCollector.daemonSet.ampexporters.authenticator }}
         
     service:
       pipelines:

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -13,6 +13,9 @@ data:
   adot-config:  |
     extensions:
       health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
+      sigv4auth:
+        service: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth.service }}
+        region: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth.region }}
     receivers:
       awscontainerinsightreceiver:
         collection_interval: {{ .Values.adotCollector.daemonSet.cwreceivers.collectionInterval }}
@@ -42,14 +45,13 @@ data:
         - {{.}}{{- end }}
         metric_declarations:
           {{ .Values.adotCollector.daemonSet.metricDeclarations | nindent 10 }}
-      awsprometheusremotewrite:
+      prometheusremotewrite:
         namespace: {{ .Values.adotCollector.daemonSet.ampexporters.namespace }}
         endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint }}
         resource_to_telemetry_conversion: 
-          enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetotel }}
-        aws_auth:
-          region: {{ .Values.adotCollector.daemonSet.ampexporters.region }}
-          service: aps
+          enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetootel }}
+        auth:
+          authenticator: {{ .Values.adotCollector.daemonSet.service.extensions.sigv4auth }}
         
     service:
       pipelines:

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -15,7 +15,7 @@ data:
       health_check: {{ .Values.adotCollector.daemonSet.extensions.healthCheck }}
       sigv4auth:
         service: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth.service }}
-        region: {{ .Values.adotCollector.daemonSet.extensions.sigv4auth.region }}
+        region: {{ .Values.awsRegion }}
     receivers:
       awscontainerinsightreceiver:
         collection_interval: {{ .Values.adotCollector.daemonSet.cwreceivers.collectionInterval }}

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1044,11 +1044,14 @@
                                 "healthCheck": {
                                     "type": "string"
                                 },
-                                "service": {
-                                    "type": "string"
-                                },
-                                "region": {
-                                    "type": "string"
+                                "sigv4auth": {
+                                    "type": "object",
+                                    "properties": {
+                                        "region": {
+                                            "type": "string"
+
+                                        }
+                                    }
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1044,14 +1044,8 @@
                                 "healthCheck": {
                                     "type": "string"
                                 },
-                                "sigv4auth": {
-                                    "type": "object",
-                                    "properties": {
-                                        "region": {
-                                            "type": "string"
-
-                                        }
-                                    }
+                                "region": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -919,12 +919,42 @@
                                             }
                                         }
                                     }
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "hostPath": {
+                                            "type": "object",
+                                            "properties": {
+                                                "path": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             ]
                         },
                         "volumeMounts": {
                             "type": "array",
                             "items": [
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "mountPath": {
+                                            "type": "string"
+                                        },
+                                        "readOnly": {
+                                            "type": "boolean"
+                                        }
+                                    }
+                                },
                                 {
                                     "type": "object",
                                     "properties": {

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1013,6 +1013,12 @@
                             "properties": {
                                 "healthCheck": {
                                     "type": "string"
+                                },
+                                "service": {
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -290,7 +290,7 @@ adotCollector:
       healthCheck: ""
       sigv4auth:
         service: "aps"
-        region: "user-region"
+        region: ""
     cwreceivers:
       collectionInterval: ""
       containerOrchestrator: ""

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -189,7 +189,7 @@ adotCollector:
   image:
     name: "aws-otel-collector"
     repository: "amazon/aws-otel-collector"
-    tag: "v0.17.0"
+    tag: "v0.21.0"
     daemonSetPullPolicy: "IfNotPresent"
     sidecarPullPolicy: "Always"
   daemonSet:
@@ -282,6 +282,9 @@ adotCollector:
         mountPath: "/conf"
     extensions:
       healthCheck: ""
+      sigv4auth:
+        service: "aps"
+        region: "user-region"
     cwreceivers:
       collectionInterval: ""
       containerOrchestrator: ""
@@ -394,14 +397,14 @@ adotCollector:
     ampexporters:
       namespaces: ""
       endpoint: ""
-      resourcetotel: false
+      resourcetootel: false
       region: ""
     service:
       metrics:
         receivers: ["prometheus"]
         processors: ["batch/metrics"]
-        exporters: ["awsprometheusremotewrite"]
-      extensions: ["health_check"]
+        exporters: ["prometheusremotewrite"]
+      extensions: ["health_check", "sigv4auth"]
 
   sidecar:
     enabled: false

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -189,7 +189,7 @@ adotCollector:
   image:
     name: "aws-otel-collector"
     repository: "amazon/aws-otel-collector"
-    tag: "v0.21.0"
+    tag: "v0.21.1"
     daemonSetPullPolicy: "IfNotPresent"
     sidecarPullPolicy: "Always"
   daemonSet:
@@ -403,7 +403,7 @@ adotCollector:
       namespaces: ""
       endpoint: ""
       resourcetootel: false
-      region: ""
+      authenticator: "sigv4auth"
     service:
       metrics:
         receivers: ["prometheus"]

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -289,7 +289,6 @@ adotCollector:
     extensions:
       healthCheck: ""
       sigv4auth:
-        service: "aps"
         region: ""
     cwreceivers:
       collectionInterval: ""

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -256,6 +256,9 @@ adotCollector:
       - name: "varlibdocker"
         hostPath:
           path: "/var/lib/docker"
+      - name: "containerdsock"
+        hostPath:
+          path: "/run/containerd/containerd.sock"
       - name: "sys"
         hostPath:
           path: "/sys"
@@ -271,6 +274,9 @@ adotCollector:
         readOnly: true
       - name: "varlibdocker"
         mountPath: "/var/lib/docker"
+        readOnly: true
+      - name: "containerdsock"
+        mountPath: "/run/containerd/containerd.sock"
         readOnly: true
       - name: "sys"
         mountPath: "/sys"


### PR DESCRIPTION
**Description:** 

This PR updates collector version v0.21.0, uses `prometheusremotewriteexporter`with `sigv4auth`, Helm version `v0.7.0`

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 

<img width="1124" alt="image" src="https://user-images.githubusercontent.com/41936996/189266461-5ea768d4-968d-4fa1-b208-b39a38abee14.png">

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
