### PR TITLE
Add value to optionally create namespace for fluent-bit

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/namespace.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit/namespace.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.fluentbit.enabled }}
+{{- if .Values.fluentbit.createNamespace }}
 # Specify namespace for Fluent Bit.
 apiVersion: v1
 kind: Namespace
@@ -7,4 +8,5 @@ metadata:
   labels:
     name: {{ include "aws-for-fluent-bit.namespace" . }}
     {{- include "aws-for-fluent-bit.labels" . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -19,6 +19,7 @@ fluentbit:
   name: "fluent-bit"
   configName: "fluent-bit-config"
   namespace: "amazon-cloudwatch"
+  createNamespace: true
   serviceAccount:
     name: "fluent-bit"
     annotations: {}


### PR DESCRIPTION
**Description:** Added fluentbit.createNamespace value defaulted to true, if set to false avoids creating the namespace. This is needed for deploying the chart via Helmfile. Deployment via Helmfile fails otherwise with an error that the namespace already exists. Using the Helmfile option to not create the namespace likewise results in an error that the namespace does not exist.

**Testing:** Deployed the forked chart successfully via helmfile

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
