### PR TITLE
fix: add missing rbac for lease creation

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
@@ -30,4 +30,7 @@ rules:
     resources: ["leases"]
     resourceNames: ["otel-container-insight-clusterleader"]
     verbs: ["get", "update", "create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create"]
 {{- end }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

With https://github.com/aws-observability/aws-otel-helm-charts/pull/62 's modification, we still need to grant permission for leases with no resource names for creation.

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
