### PR TITLE
feat: support additional processor injection from values

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -32,6 +32,7 @@ data:
     processors:
       batch/metrics:
         timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
+      {{ .Values.adotCollector.daemonSet.processors.additionalProcessors | nindent 6 }}
     exporters:
       awsemf:
         namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1074,6 +1074,9 @@
                             "properties": {
                                 "timeout": {
                                     "type": "string"
+                                },
+                                "additionalProcessors": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -298,6 +298,7 @@ adotCollector:
       addFullPodNameMetricLabel: ""
     processors:
       timeout: 60s
+      additionalProcessors: ""
     cwexporters:
       namespace: "ContainerInsights"
       logGroupName: ""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Currently, there is no easy way to add more processors in the pipeline. With this PR, it can be done by injecting the values.


For instance, I want to exclude some namespaces, I can inject values like the below to make it work.

```yaml
adotCollector:
    processors:
      timeout: 60s
      additionalProcessors: |
        filter/no-kube:
          metrics:
            exclude:
              match_type: regexp
              resource_attributes:
                - Key: Namespace
                  Value: (kube-*)
    service:
      metrics:
        receivers: ["prometheus"]
        processors: ["batch/metrics", "filter/no-kube"]
        exporters: ["prometheusremotewrite"]
```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
