### PR TITLE
Logging templates deprecation notice in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ $ helm repo add aws-observability https://aws-observability.github.io/aws-otel-h
 $ helm search repo aws-observability # Run this command in order to see the charts.
 ```
 
+###### Warning: Fluent Bit and Fargate logging templates are deprecated and will be removed from the Helm chart on December 30th, 2022
+
+There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
+
+* Removing the [Fluent Bit logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit)
+* Removing the [Fargate logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-fargate-logging)
+
+Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th, 2022 to avoid any issues.  Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ helm repo add aws-observability https://aws-observability.github.io/aws-otel-h
 $ helm search repo aws-observability # Run this command in order to see the charts.
 ```
 
-###### Warning: Fluent Bit and Fargate logging templates are deprecated and will be removed from the Helm chart on December 30th, 2022
+### Warning: Fluent Bit and Fargate logging templates are deprecated and will be removed from the Helm chart on December 30th, 2022
 
 There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
 


### PR DESCRIPTION
**Description:** Added a deprecation notice for logging templates in the Helm Chart

**Documentation:** This noticed was added to the README for a general view


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
