### PR TITLE
Upgrade Helm Chart to use v0.23.0- Helm chart release v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,3 @@ Please note that as per policy, we're providing support via GitHub on a best eff
 # Maintainers
 
 - [Anthony Mirabella](https://github.com/Aneurysm9)
-- [Ruthvik Ravindra](https://github.com/ruthvik17)

--- a/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: adot-exporter-for-eks-on-ec2
 description: A Helm chart for collecting metrics using ADOT Collector and logs using Fluent Bit to send to AWS monitoring services.
 type: application
-version: 0.8.0
+version: 0.9.0
 appVersion: "0.19.0"
 kubeVersion: ">=1.19.0-0"
 maintainers:

--- a/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/Chart.yaml
@@ -3,7 +3,7 @@ name: adot-exporter-for-eks-on-ec2
 description: A Helm chart for collecting metrics using ADOT Collector and logs using Fluent Bit to send to AWS monitoring services.
 type: application
 version: 0.9.0
-appVersion: "0.19.0"
+appVersion: "0.23.0"
 kubeVersion: ">=1.19.0-0"
 maintainers:
   - name: Bryan Aguilar

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -189,7 +189,7 @@ adotCollector:
   image:
     name: "aws-otel-collector"
     repository: "amazon/aws-otel-collector"
-    tag: "v0.22.0"
+    tag: "v0.23.0"
     daemonSetPullPolicy: "IfNotPresent"
     sidecarPullPolicy: "Always"
   daemonSet:


### PR DESCRIPTION
**Description:** 
This PR Upgrades the Helm chart to use latest ADOT collector.


**Testing:** 
<img width="1583" alt="image" src="https://user-images.githubusercontent.com/41936996/202248151-e3b66882-72d2-45e8-abab-c0aa2f0f2489.png">



**Documentation:** <Describe the documentation added.>


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
