### PR TITLE
BREAKING CHANGE: make processors configurable

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -27,11 +27,10 @@ data:
           global:
             scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval }}
             scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout }}
-          scrape_configs: 
+          scrape_configs:
             {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeConfigs | nindent 12 }}
     processors:
-      batch/metrics:
-        timeout: {{ .Values.adotCollector.daemonSet.processors.timeout }}
+      {{- .Values.adotCollector.daemonSet.processors | nindent 6 }}
     exporters:
       awsemf:
         namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}
@@ -48,11 +47,11 @@ data:
       prometheusremotewrite:
         namespace: {{ .Values.adotCollector.daemonSet.ampexporters.namespace }}
         endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint }}
-        resource_to_telemetry_conversion: 
+        resource_to_telemetry_conversion:
           enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetootel }}
         auth:
           authenticator: {{ .Values.adotCollector.daemonSet.ampexporters.authenticator }}
-        
+
     service:
       pipelines:
         metrics:

--- a/charts/adot-exporter-for-eks-on-ec2/values.schema.json
+++ b/charts/adot-exporter-for-eks-on-ec2/values.schema.json
@@ -1070,12 +1070,7 @@
                             }
                         },
                         "processors": {
-                            "type": "object",
-                            "properties": {
-                                "timeout": {
-                                    "type": "string"
-                                }
-                            }
+                            "type": "string"
                         },
                         "exporters": {
                             "type": "object",

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -296,8 +296,9 @@ adotCollector:
       addServiceAsAttribute: ""
       preferFullPodName: ""
       addFullPodNameMetricLabel: ""
-    processors:
-      timeout: 60s
+    processors: |
+      batch/metrics:
+        timeout: 60s
     cwexporters:
       namespace: "ContainerInsights"
       logGroupName: ""


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
At the moment it's not possible to configure `processors`. This change introduces the possibilities to configure them as a string similar to `metricDeclarations`. 

This is a breaking change because `processors` was an object before taking only configuration for the statically configured `batch/metrics` processor. Processor configuration can be highly dynamic that's why I recommend just accepting the configuration as plain string and insert it into the configuration.

**Testing:** <Describe what testing was performed and which tests were added.>

I've rendered the new template and deployed it with multiple processor configurations in the `values.yaml`. This worked fine.

**Documentation:** <Describe the documentation added.>

No documentation changes required.

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
