### PR TITLE
fix: set configured loggroup name for cloudwatch

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -35,7 +35,11 @@ data:
     exporters:
       awsemf:
         namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}
+        {{- if .Values.adotCollector.daemonSet.cwexporters.logGroupName }}
+        log_group_name: {{ .Values.adotCollector.daemonSet.cwexporters.logGroupName }}
+        {{- else }}
         log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/performance'
+        {{- end }}
         log_stream_name: {{ .Values.adotCollector.daemonSet.cwexporters.logStreamName }}
         region: {{ .Values.awsRegion }}
         resource_to_telemetry_conversion:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The configuration option for `logGroupName` in `cwexporters` was not used. I've introduced a conditional which uses this parameter if set, otherwise it falls back to the old config value.

**Testing:** 

Rendered templates to check if values are configured correctly.

**Documentation:**

No documentation changes required. 


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
