### PR TITLE
feat: allow adot-collector to list and watch service endpoints

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/clusterrole.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "adotCollector.daemonSet.labels" . | indent 4 }}
 rules:
   - apiGroups: [""]
-    resources: ["pods", "nodes", "endpoints"]
+    resources: ["pods", "nodes", "endpoints", "services"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
     resources: ["replicasets"]
@@ -33,4 +33,6 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
 {{- end }}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Allow the adot-collector role to list and watch service resources in k8s. This is required in order to scrape prometheus metrics from kube-state-metrics.

**Testing:** 
Deployed to a running cluster with kube state metrics and exported metrics to cloudwatch. 

**Documentation:** <Describe the documentation added.>
No documentation change required. 

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
