### PR TITLE
[adot-exporter-for-eks-on-ec2] Restart daemon set on configmap updates

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/daemonset.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         name: {{ .Values.adotCollector.daemonSet.daemonSetName }}
         {{- include "adotCollector.daemonSet.labels" . | indent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/adot-collector/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Values.adotCollector.daemonSet.containersName }}

--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.adotCollector.daemonSet.enabled -}}
+{{- if and .Values.adotCollector.daemonSet.enabled .Values.adotCollector.daemonSet.serviceAccount.create -}}
 # Service account provides identity information for a user to be able to authenticate processes running in a pod.
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
**Description:** The daemonset shall restart upon config map updates. Also, the value `adotCollector.daemonSet.serviceAccount.create` was not taken into account.

**Testing:** Locally tested.

**Documentation:** No changes in interfaces, bugfixing.


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
