### PR TITLE
Updates README with useful information after the removal of the logging templates 

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ $ helm search repo aws-observability # Run this command in order to see the char
 
 ### :warning: Warning: Fluent Bit and Fargate logging templates are deprecated and were removed from the Helm chart on December 30th, 2022 (>= 0.11.0)
 
-There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
+There is planned work in the upstream OpenTelemetry repositories to stabilize logs, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
 
 * Removing the [Fluent Bit logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit)
 * Removing the [Fargate logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-fargate-logging)
 
 Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th (<= 0.10.0), 2022 to avoid any issues. As an alternative, you can also make use of the [`aws-for-fluent-bit`](https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit) Helm Chart ([more details](https://github.com/aws-observability/aws-otel-helm-charts/issues/88)).
 
-Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
+Once logs are stabilized upstream and implemented, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ $ helm repo add aws-observability https://aws-observability.github.io/aws-otel-h
 $ helm search repo aws-observability # Run this command in order to see the charts.
 ```
 
-### Warning: Fluent Bit and Fargate logging templates are deprecated and will be removed from the Helm chart on December 30th, 2022
+### :warning: Warning: Fluent Bit and Fargate logging templates are deprecated and were removed from the Helm chart on December 30th, 2022 (>= 0.11.0)
 
 There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
 
 * Removing the [Fluent Bit logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit)
 * Removing the [Fargate logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-fargate-logging)
 
-Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th, 2022 to avoid any issues.  Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
+Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th (<= 0.10.0), 2022 to avoid any issues. As an alternative, you can also make use of the [`aws-for-fluent-bit`](https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit) Helm Chart ([more details](https://github.com/aws-observability/aws-otel-helm-charts/issues/88)).
+
+Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
 
 
 ## Contributing
@@ -34,7 +36,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
 
 This project is licensed under the Apache 2.0 License.
 
-## ADOT Roadmap 
+## ADOT Roadmap
 
 You can track upcoming features and enhancements for ADOT on its [roadmap](https://github.com/orgs/aws-observability/projects/4).
 

--- a/charts/adot-exporter-for-eks-on-ec2/README.md
+++ b/charts/adot-exporter-for-eks-on-ec2/README.md
@@ -7,14 +7,14 @@ The Helm chart configured in this repository deploys the ADOT Collector as [Daem
 
 ## :warning: Warning: Fluent Bit and Fargate logging templates are deprecated and were removed from the Helm chart on December 30th, 2022 (>= 0.11.0)
 
-There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
+There is planned work in the upstream OpenTelemetry repositories to stabilize logs, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
 
 * Removing the [Fluent Bit logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit)
 * Removing the [Fargate logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-fargate-logging)
 
 Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th (<= 0.10.0), 2022 to avoid any issues. As an alternative, you can also make use of the [`aws-for-fluent-bit`](https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit) Helm Chart ([more details](https://github.com/aws-observability/aws-otel-helm-charts/issues/88)).
 
-Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
+Once logs are stabilized upstream and implemented, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
 
 ## Helm Chart Structure
 ```console

--- a/charts/adot-exporter-for-eks-on-ec2/README.md
+++ b/charts/adot-exporter-for-eks-on-ec2/README.md
@@ -5,10 +5,21 @@ This [Helm](https://helm.sh/) chart provides easy to use [AWS Elastic Kubernetes
 
 The Helm chart configured in this repository deploys the ADOT Collector as [DaemonSets](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) and is ready to collect metrics and logs and send them to Amazon CloudWatch Container Insights and AMP.
 
+## :warning: Warning: Fluent Bit and Fargate logging templates are deprecated and were removed from the Helm chart on December 30th, 2022 (>= 0.11.0)
+
+There is planned work in the upstream OpenTelemetry repositories to stabilize logs in 2023, and so that means that our Helm Chart will have to be updated to reflect these eventual changes.  The changes required for our Helm Chart include:
+
+* Removing the [Fluent Bit logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-for-fluent-bit)
+* Removing the [Fargate logging templates](https://github.com/aws-observability/aws-otel-helm-charts/tree/main/charts/adot-exporter-for-eks-on-ec2/templates/aws-fargate-logging)
+
+Therefore, we recommend revising any code that utilizes these templates by December 30th, 2022 or continue to use the version of the Helm Chart that pre-dates December 30th (<= 0.10.0), 2022 to avoid any issues. As an alternative, you can also make use of the [`aws-for-fluent-bit`](https://github.com/aws/eks-charts/tree/master/stable/aws-for-fluent-bit) Helm Chart ([more details](https://github.com/aws-observability/aws-otel-helm-charts/issues/88)).
+
+Once logs are stabilized upstream and implemented into our Helm Chart in 2023, a new version of the Helm Chart will be released and users may upgrade to this instance instead.  Thank you for your cooperation.
+
 ## Helm Chart Structure
 ```console
 adot-exporter-for-eks-on-ec2/
-|-- scripts/ 
+|-- scripts/
 |   |-- install-tools.sh
 |   |-- lint-charts.sh
 |   |-- validate-charts.sh
@@ -27,7 +38,7 @@ adot-exporter-for-eks-on-ec2/
 |-- documentation
 |   |-- metrics_to_CloudWatch_AMP.md
 |   |-- deploy_collector_as_sidcar.md
-|   |-- aws_logging_on_Fargate.md 
+|   |-- aws_logging_on_Fargate.md
 |-- Chart.yaml
 |-- values.schema.json
 |-- values.yaml
@@ -49,7 +60,7 @@ adot-exporter-for-eks-on-ec2/
 
 The following prerequisites need to be set up in order to install this Helm chart.
 
-- Your EKS Cluster on EC2 
+- Your EKS Cluster on EC2
 - [Amazon CloudWatch Container Insights prerequisites](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-prerequisites.html)
 - Using the above instructions, please attach the ‘prometheusremotewriteacess’ policy to the nodes.
 - Your working [Amazon Managed Service for Prometheus(AMP) workspace](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-onboard-create-workspace.html).
@@ -93,7 +104,7 @@ Deploying ADOT Collector as Deployment and StatefulSet mode requires installing 
 
 ## Uninstall Chart
 
-The following command uninstalls the chart. 
+The following command uninstalls the chart.
 This will remove all the Kubernetes components associated with the chart and deletes the release.
 
 ```console


### PR DESCRIPTION


**Description:**
- Updates both the repo README and the Helm Chart README with information useful for users who might land in this repository looking for a logging integration with CloudWatch. 
- Links to `aws-for-fluent-bit` Helm Chart which provides an similar integration from the one removed in #82
- Removes a few trailing spaces in a couple other lines

**Link to tracking Issue:** #88

<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
