### PR TITLE
[FIX]: Honor adotCollector.daemonSet.cwexporters.logGroupName when set

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -35,7 +35,7 @@ data:
     exporters:
       awsemf:
         namespace: {{ .Values.adotCollector.daemonSet.cwexporters.namespace }}
-        log_group_name: '/aws/containerinsights/{{ .Values.clusterName }}/performance'
+        log_group_name: {{ default (printf "'/aws/containerinsights/%s/performance'" .Values.clusterName) .Values.adotCollector.daemonSet.cwexporters.logGroupName }}
         log_stream_name: {{ .Values.adotCollector.daemonSet.cwexporters.logStreamName }}
         region: {{ .Values.awsRegion }}
         resource_to_telemetry_conversion:


### PR DESCRIPTION
**Description:** Honor adotCollector.daemonSet.cwexporters.logGroupName when set. Currently, setting this field doesn't do anything.

**Link to tracking Issue:** N/A

**Testing:**
##### With current chart version

*Log group not set*

```
➜  charts git:(main) helm install test-release-0 aws-observability/adot-exporter-for-eks-on-ec2 \
  --set "clusterName=test-otel-cluster" --set "awsRegion=us-west-2" \
  --set "adotCollector.daemonSet.service.metrics.receivers={awscontainerinsightreceiver}" \
  --set "adotCollector.daemonSet.service.metrics.exporters={awsemf}"
NAME: test-release-0
LAST DEPLOYED: Wed Mar 22 13:39:57 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing adot-exporter-for-eks-on-ec2.

Your release is named test-release-0.

To learn more about the release, try:

  $ helm status test-release-0
  $ helm get all test-release-0

➜  charts git:(main) kubectl describe cm adot-conf -n amazon-metrics | grep log_group_name
    log_group_name: '/aws/containerinsights/test-otel-cluster/performance'
➜  charts git:(main)
```

*Log group set*

```
➜  charts git:(main) helm install test-release-0 aws-observability/adot-exporter-for-eks-on-ec2 \
  --set "clusterName=test-otel-cluster" --set "awsRegion=us-west-2" \
  --set "adotCollector.daemonSet.service.metrics.receivers={awscontainerinsightreceiver}" \
  --set "adotCollector.daemonSet.service.metrics.exporters={awsemf}" \
  --set "adotCollector.daemonSet.cwexporters.logGroupName=testLogGroup"
NAME: test-release-0
LAST DEPLOYED: Wed Mar 22 13:41:29 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing adot-exporter-for-eks-on-ec2.

Your release is named test-release-0.

To learn more about the release, try:

  $ helm status test-release-0
  $ helm get all test-release-0

➜  charts git:(main) kubectl describe cm adot-conf -n amazon-metrics | grep log_group_name
    log_group_name: '/aws/containerinsights/test-otel-cluster/performance'
➜  charts git:(main)
```

##### With fixed chart version

*Log group not set*

```
➜  charts git:(main) helm install test-release-0 adot-exporter-for-eks-on-ec2 \
  --set "clusterName=test-otel-cluster" --set "awsRegion=us-west-2" \
  --set "adotCollector.daemonSet.service.metrics.receivers={awscontainerinsightreceiver}" \
  --set "adotCollector.daemonSet.service.metrics.exporters={awsemf}"
NAME: test-release-0
LAST DEPLOYED: Wed Mar 22 13:43:43 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing adot-exporter-for-eks-on-ec2.

Your release is named test-release-0.

To learn more about the release, try:

  $ helm status test-release-0
  $ helm get all test-release-0

➜  charts git:(main) kubectl describe cm adot-conf -n amazon-metrics | grep log_group_name
    log_group_name: '/aws/containerinsights/test-otel-cluster/performance'
```

*Log group set*

```
➜  charts git:(main) helm install test-release-0 adot-exporter-for-eks-on-ec2 \
  --set "clusterName=test-otel-cluster" --set "awsRegion=us-west-2" \
  --set "adotCollector.daemonSet.service.metrics.receivers={awscontainerinsightreceiver}" \
  --set "adotCollector.daemonSet.service.metrics.exporters={awsemf}" \
  --set "adotCollector.daemonSet.cwexporters.logGroupName=testLogGroup"
NAME: test-release-0
LAST DEPLOYED: Wed Mar 22 13:45:12 2023
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Thank you for installing adot-exporter-for-eks-on-ec2.

Your release is named test-release-0.

To learn more about the release, try:

  $ helm status test-release-0
  $ helm get all test-release-0

➜  charts git:(main) kubectl describe cm adot-conf -n amazon-metrics | grep log_group_name
    log_group_name: testLogGroup
```

**Documentation:** N/A


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
