### PR TITLE
Add timeout, retry, and write queue options to AMP remote write exporter

### DIFF
--- a/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/templates/adot-collector/configmap.yaml
@@ -27,7 +27,7 @@ data:
           global:
             scrape_interval: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeInterval }}
             scrape_timeout: {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeTimeout }}
-          scrape_configs: 
+          scrape_configs:
             {{ .Values.adotCollector.daemonSet.ampreceivers.scrapeConfigs | nindent 12 }}
     processors:
       batch/metrics:
@@ -48,11 +48,24 @@ data:
       prometheusremotewrite:
         namespace: {{ .Values.adotCollector.daemonSet.ampexporters.namespace }}
         endpoint: {{ .Values.adotCollector.daemonSet.ampexporters.endpoint }}
-        resource_to_telemetry_conversion: 
+        resource_to_telemetry_conversion:
           enabled: {{ .Values.adotCollector.daemonSet.ampexporters.resourcetootel }}
         auth:
           authenticator: {{ .Values.adotCollector.daemonSet.ampexporters.authenticator }}
-        
+        timeout: {{ .Values.adotCollector.daemonSet.ampexporters.timeout }}
+        {{- if .Values.adotCollector.daemonSet.ampexporters.remote_write_queue.enabled }}
+        {{- with .Values.adotCollector.daemonSet.ampexporters.remote_write_queue }}
+        remote_write_queue:
+          {{- toYaml . | nindent 10 }}
+        {{ - end }}
+        {{- end }}
+        {{- if .Values.adotCollector.daemonSet.ampexporters.retry_on_failure.enabled }}
+        {{- with .Values.adotCollector.daemonSet.ampexporters.retry_on_failure }}
+        retry_on_failure:
+          {{- toYaml . | nindent 10 }}
+        {{ - end }}
+        {{- end }}
+
     service:
       pipelines:
         metrics:

--- a/charts/adot-exporter-for-eks-on-ec2/values.yaml
+++ b/charts/adot-exporter-for-eks-on-ec2/values.yaml
@@ -9,11 +9,6 @@ clusterName: ""
 additionalLabels: {}
   # app: adot
 
-serviceAccount:
-  create: true
-  annotations: {}
-  name: ""
-
 adotCollector:
   image:
     name: "aws-otel-collector"
@@ -233,6 +228,16 @@ adotCollector:
       endpoint: ""
       resourcetootel: false
       authenticator: "sigv4auth"
+      timeout: "5s"
+      retry_on_failure:
+        enabled: true
+        initial_interval: "5s"
+        max_interval: "30s"
+        max_elapsed_time: "300s"
+      remote_write_queue:
+        enabled: false
+        queue_size: 5000
+        num_consutmers: 10
     service:
       metrics:
         receivers: ["prometheus"]


### PR DESCRIPTION
**Description:**
Add timeout, retry, and write queue options to AMP remote write exporter as defined [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter#getting-started). Note that the timeout and retry settings are defined in the shared [Exporter Helper](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md).

All default values have been taken from the above linked documentation.

**Link to tracking Issue:** N/A

**Testing:** TBD

**Documentation:** Updated values schema


<!-- DO NOT DELETE -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
